### PR TITLE
Pre-2000 proxy splicing for gold and commodities (fixes #1)

### DIFF
--- a/configs/series.yaml
+++ b/configs/series.yaml
@@ -324,6 +324,25 @@ fred:
     frequency: monthly
     description: New privately-owned housing units started — supply constraint indicator
 
+  # --- Asset-Price Proxies (pre-2000 splicing; see backtester.md, issue #1) ---
+  WPUSI019011:
+    name: PPI Metals & Metal Products
+    category: asset_proxy
+    frequency: monthly
+    description: PPI Industry - Metals & Metal Products; monthly gold-return proxy for 1975-2000 before GC=F futures data begins
+
+  PPIACO:
+    name: PPI All Commodities
+    category: asset_proxy
+    frequency: monthly
+    description: Broad PPI All Commodities index; monthly commodity-return proxy for 1975-1986 before WTI spot data begins
+
+  DCOILWTICO:
+    name: WTI Crude Oil Spot
+    category: asset_proxy
+    frequency: daily
+    description: WTI crude oil spot price (Cushing); daily commodity-return proxy for 1986-2000 before CL=F futures data begins
+
   # --- Human Capital & Civilizational Health ---
   A939RX0Q048SBEA:
     name: Real GDP per Capita

--- a/docs/specs/backtester.md
+++ b/docs/specs/backtester.md
@@ -35,8 +35,11 @@ Specifically:
 - Start date (default: 1975-01-01)
 
 ### Outputs
-- `pd.DataFrame` with columns for each asset class, indexed by date, containing
-  daily returns (as decimals, e.g., 0.01 = 1%)
+- `pd.DataFrame` with columns for each asset class, indexed by **business day**
+  (pandas `DatetimeIndex`, no weekends, holidays permitted to be present if they
+  carry a return), containing daily returns (as decimals, e.g., 0.01 = 1%)
+- The index dtype must be `datetime64[ns]`, not `object` — downstream code
+  relies on string-based `.loc` lookups and `.year` / `.month` accessors
 
 ### Asset class definitions
 | Asset class | Primary source | Pre-data proxy | Notes |
@@ -61,7 +64,12 @@ Specifically:
   at the splice point — the combined series is continuous across the splice date.
 
 ### Edge cases
-- Weekends/holidays: returns are 0 (or dates are skipped if using business days)
+- Weekends are **not** in the index — output is business-day frequency. Saturday
+  and Sunday timestamps must not appear in `returns.index` or `sources.index`.
+- Holidays (days when the market was closed): may appear in the index with a
+  return of 0 if the underlying source dropped that day, or may be omitted. Either
+  is acceptable — the invariant is that no NaN appears on any date that IS in the
+  index.
 - Pre-data periods: covered by proxy splicing (see below). Any remaining gap must
   be explicitly documented.
 
@@ -101,11 +109,13 @@ information.
 - The spliced daily series must compound to the source's native-frequency returns
   to within 1e-6 tolerance (a daily series built from PPIACO must compound to
   PPIACO's monthly returns over any full-month window)
-- No NaN values anywhere in 1975-01-01 → present
+- No NaN values on any business day in `1975-01-01 → present` (weekends are not in
+  the index, so the invariant is vacuous on weekends)
 - No gap or overlap at splice points — every trading day belongs to exactly one source
 - The source used on each date must be queryable from the output (e.g., a
   `source` column or companion Series) so analysis can distinguish proxy from
-  primary periods
+  primary periods. Source labels must be populated on every business day the
+  returns frame is populated on.
 
 ### Test cases
 - Given WPUSI019011 monthly returns of +1% for February 1980, every trading day

--- a/docs/specs/backtester.md
+++ b/docs/specs/backtester.md
@@ -1,7 +1,7 @@
 # Backtester Specification
 
 Status: **Stabilizing**
-Last updated: 2026-04-13
+Last updated: 2026-04-13 (pre-2000 proxy splicing added — see issue #1)
 
 ## Purpose
 
@@ -44,22 +44,89 @@ Specifically:
 | equities | ^GSPC daily close | — | Available from 1975 |
 | long_bonds | Derived from 10Y yield (^TNX) | — | Return ≈ -duration × Δyield + yield/252 |
 | short_bonds | Derived from 2Y yield (GS2) | — | Return ≈ -2 × Δyield + yield/252 |
-| gold | GC=F daily close | Proxy from FRED (pre-2000) | See issue #1 |
-| commodities | CL=F daily close | Proxy from FRED (pre-2000) | See issue #1 |
+| gold | GC=F daily close (2000+) | WPUSI019011 monthly (1975-2000) | PPI: Metals & Metal Products; imperfect proxy, tracks directionally |
+| commodities | CL=F daily close (2000+) | DCOILWTICO daily (1986-2000), PPIACO monthly (1975-1986) | Two-stage proxy: WTI spot where available, PPI All Commodities before |
 | cash | FEDFUNDS / 252 | — | Monthly rate, forward-filled to daily |
 
 ### Invariants
 - All return values must be finite (no NaN, no inf)
 - Daily returns should be bounded: |r| < 0.25 for any single day (circuit breaker)
-- Missing data periods must be filled with 0 (not NaN), representing a "no data,
-  assume flat" conservative approach. (This may change — see issue #1.)
+- Every asset class must have non-zero return data for the full backtest period
+  (1975-01-01 to present). Filling missing periods with 0 is forbidden for
+  assets with an available proxy — use the proxy instead.
+- Missing data periods for assets with **no** proxy may be filled with 0 (documented
+  per asset), but this must be flagged in the backtest config so downstream analysis
+  knows the period is degenerate.
 - When proxy data is spliced with primary data, there must be no gap and no overlap
-  at the splice point
+  at the splice point — the combined series is continuous across the splice date.
 
 ### Edge cases
 - Weekends/holidays: returns are 0 (or dates are skipped if using business days)
-- Pre-data periods: currently filled with 0; should be filled with proxy returns
-  after issue #1 is resolved
+- Pre-data periods: covered by proxy splicing (see below). Any remaining gap must
+  be explicitly documented.
+
+## Proxy series splicing
+
+### Purpose
+Primary daily price sources (GC=F for gold, CL=F for commodities) only begin ~2000
+on Yahoo Finance. Without proxies, pre-2000 returns are 0 for these assets, which
+biases 1975-2000 backtest results against any strategy allocating to them.
+
+### Splice points
+| Asset class | Date range | Source | Frequency |
+|---|---|---|---|
+| gold | 1975-01-01 → 2000-08-29 | WPUSI019011 (FRED) | monthly |
+| gold | 2000-08-30 → present | GC=F (Yahoo) | daily |
+| commodities | 1975-01-01 → 1985-12-31 | PPIACO (FRED) | monthly |
+| commodities | 1986-01-02 → 2000-08-22 | DCOILWTICO (FRED) | daily |
+| commodities | 2000-08-23 → present | CL=F (Yahoo) | daily |
+
+Exact splice dates must be the first trading day that the newer source has data.
+Splice date belongs to the newer source (exclusive on the older, inclusive on the newer).
+
+### Monthly → daily return conversion
+Monthly proxy series (WPUSI019011, PPIACO) are levels, not returns. Conversion rule:
+1. Compute monthly returns from the level series: `monthly_ret = level.pct_change()`
+2. Distribute each monthly return across the trading days in that month such that
+   compounded daily returns equal the monthly return:
+   `daily_ret = (1 + monthly_ret) ** (1 / n_trading_days_in_month) - 1`
+3. Apply this daily_ret to every trading day within the month
+
+**Why even distribution:** the proxy is coarse; pretending we know intra-month
+timing we don't have would manufacture false signal. Even distribution makes
+monthly-frequency truth self-consistent at the daily level without fabricating
+information.
+
+### Invariants (splicing)
+- The spliced daily series must compound to the source's native-frequency returns
+  to within 1e-6 tolerance (a daily series built from PPIACO must compound to
+  PPIACO's monthly returns over any full-month window)
+- No NaN values anywhere in 1975-01-01 → present
+- No gap or overlap at splice points — every trading day belongs to exactly one source
+- The source used on each date must be queryable from the output (e.g., a
+  `source` column or companion Series) so analysis can distinguish proxy from
+  primary periods
+
+### Test cases
+- Given WPUSI019011 monthly returns of +1% for February 1980, every trading day
+  in February 1980 has the same daily return r where `(1+r)^n ≈ 1.01` for n
+  trading days in February 1980
+- Given the 1986-01-02 splice for commodities, 1985-12-31 belongs to PPIACO and
+  1986-01-02 belongs to DCOILWTICO; no day belongs to both
+- Given the 2000-08-23 splice for commodities, the day before belongs to
+  DCOILWTICO and the day of belongs to CL=F
+- Loading asset returns for date 1975-06-15 returns non-zero values for both
+  gold and commodities columns
+- Compounded monthly returns from the spliced daily gold series, for any full
+  month in 1975-2000, equal WPUSI019011 monthly returns for that month
+
+### Known limitations
+- WPUSI019011 is a metals-and-metal-products PPI, not a gold price; correlation
+  to actual gold returns is imperfect. This is documented tracking error accepted
+  in exchange for non-zero returns.
+- PPIACO is a broad commodity basket, not crude oil; the pre-1986 commodity
+  series measures a different thing than post-1986. This is a semantic splice,
+  not just a data-source splice — document it in backtest outputs.
 
 ## Strategy interface
 

--- a/src/backtester.py
+++ b/src/backtester.py
@@ -274,7 +274,14 @@ def build_asset_returns(
     })
 
     returns = returns.loc[start_dt:]
-    returns = returns.fillna(0)
+
+    # Zero-fill only assets with no proxy coverage (bonds/cash edge cases).
+    # Gold and commodities have spec-mandated proxy coverage from 1975 onward;
+    # any NaN there is a real gap and must surface, not be silently filled.
+    # See docs/specs/backtester.md "Asset returns → Invariants".
+    PROXIED_ASSETS = {"gold", "commodities"}
+    non_proxied_cols = [c for c in returns.columns if c not in PROXIED_ASSETS]
+    returns[non_proxied_cols] = returns[non_proxied_cols].fillna(0)
 
     if not return_sources:
         return returns

--- a/src/backtester.py
+++ b/src/backtester.py
@@ -9,6 +9,21 @@ import numpy as np
 from dataclasses import dataclass, field
 from typing import Protocol
 
+# ---------------------------------------------------------------------------
+# Pre-2000 proxy splicing configuration (see docs/specs/backtester.md, issue #1)
+# ---------------------------------------------------------------------------
+
+GOLD_PROXY_SERIES = "WPUSI019011"
+COMMODITIES_MONTHLY_PROXY_SERIES = "PPIACO"
+COMMODITIES_DAILY_PROXY_SERIES = "DCOILWTICO"
+
+# Splice dates are best-guess defaults; the actual splice date is derived
+# dynamically as the first trading day on which the newer source has data
+# (belongs to the newer source — exclusive on older, inclusive on newer).
+GOLD_DEFAULT_SPLICE = pd.Timestamp("2000-08-30")
+COMMODITIES_MONTHLY_TO_DAILY_SPLICE = pd.Timestamp("1986-01-02")
+COMMODITIES_DAILY_TO_FUTURES_SPLICE = pd.Timestamp("2000-08-23")
+
 
 # ---------------------------------------------------------------------------
 # Data structures
@@ -41,10 +56,154 @@ class BacktestResult:
 # Asset price proxies
 # ---------------------------------------------------------------------------
 
+def _as_series(obj) -> pd.Series:
+    """Normalize a Series or single-column DataFrame to a Series."""
+    if isinstance(obj, pd.DataFrame):
+        return obj.squeeze("columns")
+    return obj
+
+
+def monthly_levels_to_daily_returns(
+    monthly_levels: pd.Series,
+    trading_index: pd.DatetimeIndex,
+) -> pd.Series:
+    """
+    Convert a monthly level series to a daily-return series aligned to trading days.
+
+    Distributes each monthly return evenly across the trading days within that
+    month such that the compounded daily returns equal the monthly return.
+
+    Parameters
+    ----------
+    monthly_levels
+        Monthly index series of price/index levels.
+    trading_index
+        Target daily DatetimeIndex (e.g., equities trading days). Output aligns
+        to these dates.
+
+    Returns
+    -------
+    pd.Series indexed by ``trading_index`` with daily returns. Days outside the
+    monthly series' coverage are NaN.
+    """
+    monthly_levels = monthly_levels.dropna().sort_index()
+    if monthly_levels.empty:
+        return pd.Series(np.nan, index=trading_index, dtype=float)
+
+    monthly_returns = monthly_levels.pct_change()
+
+    trading_index = pd.DatetimeIndex(trading_index).sort_values()
+    period_key = trading_index.to_period("M")
+
+    days_per_month_map = pd.Series(period_key).value_counts()
+
+    monthly_returns_by_period = pd.Series(
+        monthly_returns.values, index=monthly_returns.index.to_period("M")
+    )
+    aligned_monthly = monthly_returns_by_period.reindex(period_key).values
+    n_days = days_per_month_map.reindex(period_key).values.astype(float)
+
+    daily_values = (1.0 + aligned_monthly) ** (1.0 / n_days) - 1.0
+    return pd.Series(daily_values, index=trading_index)
+
+
+def splice_returns(
+    segments: list[tuple[pd.Series, str]],
+) -> tuple[pd.Series, pd.Series]:
+    """
+    Splice ordered return segments into one continuous daily return series.
+
+    Each segment is ``(returns, source_label)``. Segments are processed in order;
+    earlier segments cover earlier dates. For each date present in a later
+    segment, that segment wins — the splice date is the first date at which the
+    newer segment has data, belonging exclusively to the newer source.
+
+    Returns
+    -------
+    (returns, sources) — both indexed by the union of segment indices.
+    ``returns`` holds float daily returns, ``sources`` holds the string label of
+    the source that supplied each date.
+    """
+    if not segments:
+        return pd.Series(dtype=float), pd.Series(dtype=object)
+
+    full_index = segments[0][0].index
+    for seg, _ in segments[1:]:
+        full_index = full_index.union(seg.index)
+    full_index = full_index.sort_values()
+
+    returns = pd.Series(np.nan, index=full_index, dtype=float)
+    sources = pd.Series(pd.NA, index=full_index, dtype=object)
+
+    for seg_returns, label in segments:
+        seg_returns = seg_returns.dropna()
+        returns.loc[seg_returns.index] = seg_returns.values
+        sources.loc[seg_returns.index] = label
+
+    return returns, sources
+
+
+def _build_gold_returns(
+    data: dict[str, pd.DataFrame],
+    trading_index: pd.DatetimeIndex,
+) -> tuple[pd.Series, pd.Series]:
+    """Build spliced daily gold returns: WPUSI019011 (pre-2000) -> GC=F."""
+    segments: list[tuple[pd.Series, str]] = []
+
+    proxy = data.get(GOLD_PROXY_SERIES)
+    if proxy is not None:
+        proxy_levels = _as_series(proxy)
+        proxy_daily = monthly_levels_to_daily_returns(proxy_levels, trading_index)
+        segments.append((proxy_daily, GOLD_PROXY_SERIES))
+
+    gold = data.get("GC=F")
+    if gold is not None:
+        primary_ret = gold["Close"].pct_change()
+        segments.append((primary_ret, "GC=F"))
+
+    if not segments:
+        empty = pd.Series(dtype=float, index=trading_index)
+        return empty, pd.Series(pd.NA, index=trading_index, dtype=object)
+
+    return splice_returns(segments)
+
+
+def _build_commodities_returns(
+    data: dict[str, pd.DataFrame],
+    trading_index: pd.DatetimeIndex,
+) -> tuple[pd.Series, pd.Series]:
+    """Build spliced daily commodities returns: PPIACO -> DCOILWTICO -> CL=F."""
+    segments: list[tuple[pd.Series, str]] = []
+
+    ppiaco = data.get(COMMODITIES_MONTHLY_PROXY_SERIES)
+    if ppiaco is not None:
+        ppiaco_levels = _as_series(ppiaco)
+        ppiaco_daily = monthly_levels_to_daily_returns(ppiaco_levels, trading_index)
+        segments.append((ppiaco_daily, COMMODITIES_MONTHLY_PROXY_SERIES))
+
+    wti = data.get(COMMODITIES_DAILY_PROXY_SERIES)
+    if wti is not None:
+        wti_levels = _as_series(wti).dropna()
+        wti_ret = wti_levels.pct_change()
+        segments.append((wti_ret, COMMODITIES_DAILY_PROXY_SERIES))
+
+    oil = data.get("CL=F")
+    if oil is not None:
+        primary_ret = oil["Close"].pct_change()
+        segments.append((primary_ret, "CL=F"))
+
+    if not segments:
+        empty = pd.Series(dtype=float, index=trading_index)
+        return empty, pd.Series(pd.NA, index=trading_index, dtype=object)
+
+    return splice_returns(segments)
+
+
 def build_asset_returns(
     data: dict[str, pd.DataFrame],
     start: str = "1975-01-01",
-) -> pd.DataFrame:
+    return_sources: bool = False,
+) -> pd.DataFrame | tuple[pd.DataFrame, pd.DataFrame]:
     """
     Build daily returns for investable asset classes.
 
@@ -52,59 +211,55 @@ def build_asset_returns(
     - equities: S&P 500 total return (price-only as proxy)
     - long_bonds: 10Y Treasury return approximation from yield changes
     - short_bonds: approximate short bond return from 2Y yield
-    - gold: Gold futures (or London fix before 2000)
-    - commodities: Oil futures (imperfect but available)
+    - gold: GC=F futures, spliced with WPUSI019011 (FRED) for 1975-2000
+    - commodities: CL=F futures, spliced with DCOILWTICO (FRED) for 1986-2000
+      and PPIACO (FRED) for 1975-1986 — see docs/specs/backtester.md
     - cash: Fed funds rate / 252 (daily risk-free)
+
+    Parameters
+    ----------
+    data
+        Mapping from series id to cached DataFrame/Series. Expected keys include
+        ``^GSPC``, ``^TNX``, ``GC=F``, ``CL=F``, ``FEDFUNDS``, and the proxy
+        series ``WPUSI019011``, ``PPIACO``, ``DCOILWTICO``.
+    start
+        Backtest start date (default: 1975-01-01).
+    return_sources
+        If True, also return a DataFrame of string source labels per date/asset
+        so downstream analysis can distinguish proxy from primary periods.
     """
     start_dt = pd.Timestamp(start)
 
-    # Equities: S&P 500 daily returns
     sp500 = data.get("^GSPC")
     if sp500 is not None:
         eq_ret = sp500["Close"].pct_change()
+        trading_index = sp500.index
     else:
         eq_ret = pd.Series(dtype=float)
+        trading_index = pd.DatetimeIndex([])
 
-    # Long bonds: approximate from 10Y yield changes
-    # Bond return ≈ -duration * Δyield + yield/252
-    # Use duration ~ 8 for 10Y Treasury
     tnx = data.get("^TNX")
     if tnx is not None:
-        y = tnx["Close"] / 100  # convert to decimal
+        y = tnx["Close"] / 100
         duration = 8.0
         bond_ret = -duration * y.diff() + y.shift(1) / 252
-        bond_ret = bond_ret.clip(-0.10, 0.10)  # cap extreme moves
+        bond_ret = bond_ret.clip(-0.10, 0.10)
     else:
         bond_ret = pd.Series(dtype=float)
 
-    # Short bonds: approximate from 2Y yield (duration ~2)
     gs2 = data.get("GS2_yield")
     if gs2 is not None:
         y2 = gs2 / 100
         short_bond_ret = -2.0 * y2.diff() + y2.shift(1) / 252
         short_bond_ret = short_bond_ret.clip(-0.05, 0.05)
     else:
-        # Fall back to cash-like return
         short_bond_ret = pd.Series(dtype=float)
 
-    # Gold
-    gold = data.get("GC=F")
-    if gold is not None:
-        gold_ret = gold["Close"].pct_change()
-    else:
-        gold_ret = pd.Series(dtype=float)
+    gold_ret, gold_src = _build_gold_returns(data, trading_index)
+    comm_ret, comm_src = _build_commodities_returns(data, trading_index)
 
-    # Commodities (oil as proxy)
-    oil = data.get("CL=F")
-    if oil is not None:
-        comm_ret = oil["Close"].pct_change()
-    else:
-        comm_ret = pd.Series(dtype=float)
-
-    # Cash: fed funds daily
     ff = data.get("FEDFUNDS")
     if ff is not None:
-        # Monthly rate, convert to daily
         ff_daily = ff.squeeze().resample("D").ffill() / 100 / 252
     else:
         ff_daily = pd.Series(dtype=float)
@@ -118,11 +273,22 @@ def build_asset_returns(
         "cash": ff_daily,
     })
 
-    # Align to common date range starting from start_dt
     returns = returns.loc[start_dt:]
     returns = returns.fillna(0)
 
-    return returns
+    if not return_sources:
+        return returns
+
+    sources = pd.DataFrame({
+        "equities": "^GSPC",
+        "long_bonds": "^TNX",
+        "short_bonds": "GS2_yield",
+        "gold": gold_src,
+        "commodities": comm_src,
+        "cash": "FEDFUNDS",
+    }, index=returns.index)
+
+    return returns, sources
 
 
 # ---------------------------------------------------------------------------

--- a/src/backtester.py
+++ b/src/backtester.py
@@ -125,7 +125,11 @@ def splice_returns(
     the source that supplied each date.
     """
     if not segments:
-        return pd.Series(dtype=float), pd.Series(dtype=object)
+        empty_idx = pd.DatetimeIndex([])
+        return (
+            pd.Series(dtype=float, index=empty_idx),
+            pd.Series(dtype=object, index=empty_idx),
+        )
 
     full_index = segments[0][0].index
     for seg, _ in segments[1:]:
@@ -136,9 +140,9 @@ def splice_returns(
     sources = pd.Series(pd.NA, index=full_index, dtype=object)
 
     for seg_returns, label in segments:
-        seg_returns = seg_returns.dropna()
-        returns.loc[seg_returns.index] = seg_returns.values
         sources.loc[seg_returns.index] = label
+        seg_valid = seg_returns.dropna()
+        returns.loc[seg_valid.index] = seg_valid.values
 
     return returns, sources
 
@@ -230,12 +234,14 @@ def build_asset_returns(
     """
     start_dt = pd.Timestamp(start)
 
+    empty_datetime_series = pd.Series(dtype=float, index=pd.DatetimeIndex([]))
+
     sp500 = data.get("^GSPC")
     if sp500 is not None:
         eq_ret = sp500["Close"].pct_change()
         trading_index = sp500.index
     else:
-        eq_ret = pd.Series(dtype=float)
+        eq_ret = empty_datetime_series.copy()
         trading_index = pd.DatetimeIndex([])
 
     tnx = data.get("^TNX")
@@ -245,7 +251,7 @@ def build_asset_returns(
         bond_ret = -duration * y.diff() + y.shift(1) / 252
         bond_ret = bond_ret.clip(-0.10, 0.10)
     else:
-        bond_ret = pd.Series(dtype=float)
+        bond_ret = empty_datetime_series.copy()
 
     gs2 = data.get("GS2_yield")
     if gs2 is not None:
@@ -253,7 +259,7 @@ def build_asset_returns(
         short_bond_ret = -2.0 * y2.diff() + y2.shift(1) / 252
         short_bond_ret = short_bond_ret.clip(-0.05, 0.05)
     else:
-        short_bond_ret = pd.Series(dtype=float)
+        short_bond_ret = empty_datetime_series.copy()
 
     gold_ret, gold_src = _build_gold_returns(data, trading_index)
     comm_ret, comm_src = _build_commodities_returns(data, trading_index)
@@ -262,7 +268,7 @@ def build_asset_returns(
     if ff is not None:
         ff_daily = ff.squeeze().resample("D").ffill() / 100 / 252
     else:
-        ff_daily = pd.Series(dtype=float)
+        ff_daily = empty_datetime_series.copy()
 
     returns = pd.DataFrame({
         "equities": eq_ret,

--- a/src/backtester.py
+++ b/src/backtester.py
@@ -266,7 +266,7 @@ def build_asset_returns(
 
     ff = data.get("FEDFUNDS")
     if ff is not None:
-        ff_daily = ff.squeeze().resample("D").ffill() / 100 / 252
+        ff_daily = ff.squeeze().resample("B").ffill() / 100 / 252
     else:
         ff_daily = empty_datetime_series.copy()
 
@@ -278,6 +278,8 @@ def build_asset_returns(
         "commodities": comm_ret,
         "cash": ff_daily,
     })
+
+    returns = returns[returns.index.dayofweek < 5]
 
     returns = returns.loc[start_dt:]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,8 @@
+"""Pytest configuration: make the ``src`` package importable for tests."""
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/test_proxy_splicing.py
+++ b/tests/test_proxy_splicing.py
@@ -12,9 +12,12 @@ import pandas as pd
 import pytest
 
 from src.backtester import (
-    GOLD_PROXY_SERIES,
-    COMMODITIES_MONTHLY_PROXY_SERIES,
     COMMODITIES_DAILY_PROXY_SERIES,
+    COMMODITIES_DAILY_TO_FUTURES_SPLICE,
+    COMMODITIES_MONTHLY_PROXY_SERIES,
+    COMMODITIES_MONTHLY_TO_DAILY_SPLICE,
+    GOLD_DEFAULT_SPLICE,
+    GOLD_PROXY_SERIES,
     build_asset_returns,
     monthly_levels_to_daily_returns,
     splice_returns,
@@ -144,22 +147,47 @@ def test_splice_has_no_overlap_and_no_gap(synthetic_data):
         synthetic_data, start="1975-01-01", return_sources=True
     )
 
+    start = pd.Timestamp("1975-01-01")
+    end = returns.index[-1]
+    full_range = (returns.index >= start) & (returns.index <= end)
+
+    # No-gap: every trading day in the intended coverage range has both a
+    # source label and a (non-zero-filled) return for the proxied assets.
+    # If Fix 1 revealed a gap the splice missed, these assertions fail.
     for asset in ("gold", "commodities"):
-        src = sources[asset].dropna()
-        assert not src.isna().any()
-        assert returns[asset].notna().all()
+        src = sources.loc[full_range, asset]
+        ret = returns.loc[full_range, asset]
+        assert src.notna().all(), (
+            f"{asset}: source label has NaN in 1975-{end.date()} range"
+        )
+        assert ret.notna().all(), (
+            f"{asset}: returns have NaN in 1975-{end.date()} range"
+        )
 
-    gold_before = sources.loc[:"2000-08-29", "gold"].dropna()
-    gold_after = sources.loc["2000-08-30":, "gold"].dropna()
-    assert set(gold_before.unique()).issubset({GOLD_PROXY_SERIES})
-    assert set(gold_after.unique()).issubset({"GC=F"})
+    # No-overlap: at each splice boundary, the day before the splice belongs to
+    # the older source and the day of the splice belongs to the newer source.
+    def _prev_trading_day(idx: pd.DatetimeIndex, boundary: pd.Timestamp) -> pd.Timestamp:
+        prior = idx[idx < boundary]
+        assert len(prior) > 0, f"no trading day before {boundary.date()}"
+        return prior[-1]
 
-    comm_ppi = sources.loc[:"1985-12-31", "commodities"].dropna()
-    comm_wti = sources.loc["1986-01-02":"2000-08-22", "commodities"].dropna()
-    comm_fut = sources.loc["2000-08-23":, "commodities"].dropna()
-    assert set(comm_ppi.unique()).issubset({COMMODITIES_MONTHLY_PROXY_SERIES})
-    assert set(comm_wti.unique()).issubset({COMMODITIES_DAILY_PROXY_SERIES})
-    assert set(comm_fut.unique()).issubset({"CL=F"})
+    gold_splice = GOLD_DEFAULT_SPLICE
+    gold_prev = _prev_trading_day(sources.index, gold_splice)
+    assert sources.loc[gold_prev, "gold"] == GOLD_PROXY_SERIES
+    assert sources.loc[gold_splice, "gold"] == "GC=F"
+    assert sources.loc[gold_prev, "gold"] != sources.loc[gold_splice, "gold"]
+
+    ppi_to_wti = COMMODITIES_MONTHLY_TO_DAILY_SPLICE
+    ppi_prev = _prev_trading_day(sources.index, ppi_to_wti)
+    assert sources.loc[ppi_prev, "commodities"] == COMMODITIES_MONTHLY_PROXY_SERIES
+    assert sources.loc[ppi_to_wti, "commodities"] == COMMODITIES_DAILY_PROXY_SERIES
+    assert sources.loc[ppi_prev, "commodities"] != sources.loc[ppi_to_wti, "commodities"]
+
+    wti_to_fut = COMMODITIES_DAILY_TO_FUTURES_SPLICE
+    wti_prev = _prev_trading_day(sources.index, wti_to_fut)
+    assert sources.loc[wti_prev, "commodities"] == COMMODITIES_DAILY_PROXY_SERIES
+    assert sources.loc[wti_to_fut, "commodities"] == "CL=F"
+    assert sources.loc[wti_prev, "commodities"] != sources.loc[wti_to_fut, "commodities"]
 
 
 def test_commodities_splice_boundary(synthetic_data):

--- a/tests/test_proxy_splicing.py
+++ b/tests/test_proxy_splicing.py
@@ -1,0 +1,242 @@
+"""Tests for pre-2000 proxy splicing in ``build_asset_returns``.
+
+Covers the test cases listed in ``docs/specs/backtester.md`` under
+"Proxy series splicing". Tests use small synthetic DataFrames so they do not
+require a FRED API key or network access.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from src.backtester import (
+    GOLD_PROXY_SERIES,
+    COMMODITIES_MONTHLY_PROXY_SERIES,
+    COMMODITIES_DAILY_PROXY_SERIES,
+    build_asset_returns,
+    monthly_levels_to_daily_returns,
+    splice_returns,
+)
+
+
+# ---------------------------------------------------------------------------
+# Synthetic fixture construction
+# ---------------------------------------------------------------------------
+
+def _business_days(start: str, end: str) -> pd.DatetimeIndex:
+    return pd.bdate_range(start=start, end=end)
+
+
+def _make_price_df(index: pd.DatetimeIndex, start_price: float = 100.0,
+                   drift: float = 0.0002, seed: int = 0) -> pd.DataFrame:
+    rng = np.random.default_rng(seed)
+    rets = rng.normal(drift, 0.01, size=len(index))
+    prices = start_price * np.cumprod(1.0 + rets)
+    return pd.DataFrame({"Close": prices}, index=index)
+
+
+def _make_monthly_levels(start: str, end: str, start_level: float = 100.0,
+                         monthly_drift: float = 0.005, seed: int = 1) -> pd.Series:
+    idx = pd.date_range(start=start, end=end, freq="MS")
+    rng = np.random.default_rng(seed)
+    rets = rng.normal(monthly_drift, 0.02, size=len(idx))
+    levels = start_level * np.cumprod(1.0 + rets)
+    return pd.Series(levels, index=idx, name="level")
+
+
+def _make_daily_levels(index: pd.DatetimeIndex, start_level: float = 30.0,
+                       drift: float = 0.0003, seed: int = 2) -> pd.DataFrame:
+    rng = np.random.default_rng(seed)
+    rets = rng.normal(drift, 0.015, size=len(index))
+    levels = start_level * np.cumprod(1.0 + rets)
+    return pd.DataFrame({"Close": levels}, index=index)
+
+
+@pytest.fixture
+def trading_index() -> pd.DatetimeIndex:
+    return _business_days("1975-01-01", "2005-12-31")
+
+
+@pytest.fixture
+def synthetic_data(trading_index: pd.DatetimeIndex) -> dict:
+    """Minimal synthetic ``data`` dict covering all splicing segments."""
+    wpu = _make_monthly_levels("1974-12-01", "2026-01-01", seed=10)
+    ppiaco = _make_monthly_levels("1974-12-01", "2026-01-01", seed=11)
+
+    wti_idx = _business_days("1986-01-02", "2026-01-01")
+    wti = _make_daily_levels(wti_idx, seed=12)
+
+    gc_idx = _business_days("2000-08-30", "2026-01-01")
+    gc = _make_price_df(gc_idx, start_price=275.0, seed=13)
+
+    cl_idx = _business_days("2000-08-23", "2026-01-01")
+    cl = _make_price_df(cl_idx, start_price=32.0, seed=14)
+
+    sp = _make_price_df(trading_index, start_price=70.0, drift=0.0003, seed=15)
+    tnx = _make_price_df(trading_index, start_price=7.5, drift=0.0, seed=16)
+
+    fed = pd.Series(
+        5.0,
+        index=pd.date_range("1975-01-01", "2026-01-01", freq="MS"),
+        name="FEDFUNDS",
+    )
+
+    return {
+        "^GSPC": sp,
+        "^TNX": tnx,
+        "FEDFUNDS": fed,
+        GOLD_PROXY_SERIES: wpu,
+        COMMODITIES_MONTHLY_PROXY_SERIES: ppiaco,
+        COMMODITIES_DAILY_PROXY_SERIES: wti,
+        "GC=F": gc,
+        "CL=F": cl,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Monthly -> daily conversion invariant
+# ---------------------------------------------------------------------------
+
+def test_monthly_to_daily_compounding_identity():
+    """Compounded daily returns equal the underlying monthly return."""
+    idx = _business_days("1980-01-01", "1980-12-31")
+    levels = pd.Series(
+        [100.0, 101.0, 99.5, 102.3, 103.0, 104.1, 106.0, 105.5, 107.0,
+         108.2, 109.0, 110.5, 111.0],
+        index=pd.date_range("1979-12-01", periods=13, freq="MS"),
+    )
+
+    daily = monthly_levels_to_daily_returns(levels, idx)
+
+    monthly_returns = levels.pct_change().dropna()
+    for period, expected in monthly_returns.items():
+        mask = (idx.year == period.year) & (idx.month == period.month)
+        month_days = daily[mask].dropna()
+        if len(month_days) == 0:
+            continue
+        compounded = (1.0 + month_days).prod() - 1.0
+        assert compounded == pytest.approx(expected, abs=1e-9), (
+            f"Month {period.date()} expected {expected}, got {compounded}"
+        )
+
+
+def test_monthly_to_daily_evenly_distributed():
+    """Within a month, every trading day receives the same daily return."""
+    idx = _business_days("1980-02-01", "1980-02-29")
+    levels = pd.Series(
+        [100.0, 101.0],
+        index=pd.date_range("1980-01-01", periods=2, freq="MS"),
+    )
+    daily = monthly_levels_to_daily_returns(levels, idx)
+    feb = daily.dropna()
+    assert len(feb) > 0
+    assert feb.nunique() == 1
+
+
+# ---------------------------------------------------------------------------
+# Splice invariants: no gap / no overlap
+# ---------------------------------------------------------------------------
+
+def test_splice_has_no_overlap_and_no_gap(synthetic_data):
+    returns, sources = build_asset_returns(
+        synthetic_data, start="1975-01-01", return_sources=True
+    )
+
+    for asset in ("gold", "commodities"):
+        src = sources[asset].dropna()
+        assert not src.isna().any()
+        assert returns[asset].notna().all()
+
+    gold_before = sources.loc[:"2000-08-29", "gold"].dropna()
+    gold_after = sources.loc["2000-08-30":, "gold"].dropna()
+    assert set(gold_before.unique()).issubset({GOLD_PROXY_SERIES})
+    assert set(gold_after.unique()).issubset({"GC=F"})
+
+    comm_ppi = sources.loc[:"1985-12-31", "commodities"].dropna()
+    comm_wti = sources.loc["1986-01-02":"2000-08-22", "commodities"].dropna()
+    comm_fut = sources.loc["2000-08-23":, "commodities"].dropna()
+    assert set(comm_ppi.unique()).issubset({COMMODITIES_MONTHLY_PROXY_SERIES})
+    assert set(comm_wti.unique()).issubset({COMMODITIES_DAILY_PROXY_SERIES})
+    assert set(comm_fut.unique()).issubset({"CL=F"})
+
+
+def test_commodities_splice_boundary(synthetic_data):
+    """The day before each splice belongs to the older source; the day of, to the newer."""
+    _, sources = build_asset_returns(
+        synthetic_data, start="1975-01-01", return_sources=True
+    )
+    assert sources.loc["1985-12-31", "commodities"] == COMMODITIES_MONTHLY_PROXY_SERIES
+    assert sources.loc["1986-01-02", "commodities"] == COMMODITIES_DAILY_PROXY_SERIES
+    assert sources.loc["2000-08-22", "commodities"] == COMMODITIES_DAILY_PROXY_SERIES
+    assert sources.loc["2000-08-23", "commodities"] == "CL=F"
+
+
+# ---------------------------------------------------------------------------
+# Non-zero returns pre-2000
+# ---------------------------------------------------------------------------
+
+def test_nonzero_returns_for_gold_and_commodities_in_1975(synthetic_data):
+    """At 1975-06-15, gold and commodities must have real (non-zero) returns."""
+    returns = build_asset_returns(synthetic_data, start="1975-01-01")
+
+    target = pd.Timestamp("1975-06-15")
+    nearest = returns.index.asof(target)
+    assert nearest is not pd.NaT
+
+    window = returns.loc[:nearest].tail(10)
+    assert (window["gold"] != 0).any(), "Gold returns are all zero pre-2000"
+    assert (window["commodities"] != 0).any(), "Commodity returns are all zero pre-2000"
+
+
+# ---------------------------------------------------------------------------
+# Spliced gold returns reproduce WPUSI019011 monthly returns
+# ---------------------------------------------------------------------------
+
+def test_spliced_gold_monthly_returns_match_proxy(synthetic_data):
+    """For any full month in 1975-2000, compounded daily gold returns equal
+    WPUSI019011 monthly returns."""
+    returns = build_asset_returns(synthetic_data, start="1975-01-01")
+
+    wpu = synthetic_data[GOLD_PROXY_SERIES]
+    monthly_proxy = wpu.pct_change().dropna()
+
+    test_months = [
+        pd.Timestamp("1975-06-01"),
+        pd.Timestamp("1980-02-01"),
+        pd.Timestamp("1990-12-01"),
+        pd.Timestamp("1999-07-01"),
+    ]
+
+    for month_start in test_months:
+        mask = (
+            (returns.index.year == month_start.year)
+            & (returns.index.month == month_start.month)
+        )
+        month_daily = returns.loc[mask, "gold"]
+        if month_daily.empty:
+            continue
+        compounded = (1.0 + month_daily).prod() - 1.0
+        expected = monthly_proxy.loc[month_start]
+        assert compounded == pytest.approx(expected, abs=1e-6), (
+            f"Month {month_start.date()}: expected {expected}, got {compounded}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# splice_returns primitive: newer source wins on overlap
+# ---------------------------------------------------------------------------
+
+def test_splice_returns_newer_wins():
+    idx_a = pd.date_range("2000-01-01", periods=5, freq="D")
+    idx_b = pd.date_range("2000-01-04", periods=5, freq="D")
+    a = pd.Series([0.01] * 5, index=idx_a)
+    b = pd.Series([0.02] * 5, index=idx_b)
+
+    out, src = splice_returns([(a, "A"), (b, "B")])
+    assert out.loc["2000-01-03"] == pytest.approx(0.01)
+    assert out.loc["2000-01-04"] == pytest.approx(0.02)
+    assert src.loc["2000-01-03"] == "A"
+    assert src.loc["2000-01-04"] == "B"
+    assert src.loc["2000-01-08"] == "B"


### PR DESCRIPTION
## Summary

Fixes #1. Before this change, gold (GC=F) and crude-oil futures (CL=F) returns were 0% for 1975-2000 because Yahoo Finance data doesn't go that far back — biasing ~25 years of backtest results for any strategy that allocates to gold or commodities.

This PR splices FRED proxy series into the pre-2000 period so both assets have real returns across the full backtest range.

### Changes
**Spec (`docs/specs/backtester.md`) — 3 commits:**
- Define the pre-2000 proxy splicing (splice points table, monthly→daily conversion rule, invariants, test cases, known limitations)
- Clarify business-day index and explicit DatetimeIndex dtype requirement (surfaced by test failures)

**Implementation (`src/backtester.py`):**
- Gold: WPUSI019011 (PPI Metals, monthly) → GC=F (2000-08-30+)
- Commodities: PPIACO (PPI All Commodities, monthly, 1975-1986) → DCOILWTICO (WTI spot, daily, 1986-2000) → CL=F (2000-08-23+)
- Monthly-to-daily: even distribution across trading days such that compounded daily = source monthly
- Data-driven splice (newer source wins wherever it has data) rather than hardcoded dates
- Opt-in `return_sources=True` flag returns a companion `DataFrame` of source labels per (date, asset)
- Business-day index throughout; no weekends in the output

**Tests (`tests/test_proxy_splicing.py`):** 7 tests, all passing, cover every spec test case plus splice-primitive unit coverage.

**Config (`configs/series.yaml`):** Registered WPUSI019011, PPIACO, DCOILWTICO.

### Spec trail
- [140abb1](https://github.com/dsdale24/big-cycle-investing/commit/140abb1) — spec update: proxy splicing
- [a713f35](https://github.com/dsdale24/big-cycle-investing/commit/a713f35) — initial implementation
- [c7ae5b3](https://github.com/dsdale24/big-cycle-investing/commit/c7ae5b3) — review fixes (scoped fillna, real no-gap test)
- [e03a135](https://github.com/dsdale24/big-cycle-investing/commit/e03a135) — dtype + splice-boundary label fix (surfaced by running tests)
- [a20876f](https://github.com/dsdale24/big-cycle-investing/commit/a20876f) — spec update: business-day index, DatetimeIndex dtype
- [70f1d5c](https://github.com/dsdale24/big-cycle-investing/commit/70f1d5c) — business-day index conformance

### Workflow notes

First end-to-end run of the maker-checker model:
- Coordinator wrote/updated specs; did not write implementation code
- Three coding agents + one review agent; each delegation had scope boundaries and effort budgets
- Review agent caught 2 Major issues before merge
- Running `pytest` (newly allowed in `.claude/settings.local.json`) caught 2 production bugs that code review alone didn't — good evidence that "run the tests" is part of the coordinator's job
- The "report-don't-patch" rule (codified mid-flight in PR #17) correctly stopped an agent that encountered a stale-base worktree instead of silently working around it

### Follow-ups filed
- #15 — Level 1/2/3 Claude-in-the-loop PR review
- #18 — Testing spec (pytest markers, worktree boundary, CI)

## Test plan
- [x] `pytest tests/` — 7/7 pass
- [ ] Coordinator re-runs `python scripts/fetch_data.py` to pull the three new FRED proxy series after merge (registered in config but data wasn't refetched on this branch)
- [ ] Re-run `notebooks/03_backtest.ipynb` with the new data to see the 1975-2000 performance delta — separate follow-up, not blocking this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)