### PR TITLE
Fix subagent worktree base: WorktreeCreate hook + .worktreeinclude

### DIFF
--- a/.claude/hooks/create_worktree_from_head.py
+++ b/.claude/hooks/create_worktree_from_head.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""WorktreeCreate hook: branch new worktrees from the current HEAD.
+
+Claude Code's default behavior branches worktrees from origin/HEAD (the
+remote default branch, typically main) regardless of which branch the
+coordinator is on. That's wrong for this project's maker-checker workflow:
+when the coordinator delegates from a feature branch with in-progress spec
+updates or intermediate commits, the agent must see those updates.
+
+This hook replaces the default with `git worktree add <path> HEAD` so the
+worktree is based at whatever the coordinator currently has checked out.
+
+Input (stdin): JSON with .worktree_path and .cwd (see Claude Code hook docs).
+Output (stdout): the absolute worktree path, on success.
+Exit: 0 on success, non-zero to abort worktree creation.
+
+Cross-platform: stdlib only, no jq or bash required.
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+
+
+def main() -> int:
+    try:
+        payload = json.load(sys.stdin)
+    except json.JSONDecodeError as err:
+        print(f"create_worktree_from_head: invalid JSON on stdin: {err}", file=sys.stderr)
+        return 1
+
+    worktree_path = payload.get("worktree_path")
+    worktree_name = payload.get("worktree_name")
+    project_cwd = payload.get("cwd")
+    if not worktree_path or not project_cwd or not worktree_name:
+        print(
+            "create_worktree_from_head: payload missing worktree_path, worktree_name, or cwd",
+            file=sys.stderr,
+        )
+        return 1
+
+    # Match Claude Code's default branch-naming convention (worktree-<name>).
+    # Without -b, the worktree is detached-HEAD and any commits the agent
+    # makes are not reachable from a named branch.
+    branch_name = f"worktree-{worktree_name}"
+    result = subprocess.run(
+        ["git", "worktree", "add", "-b", branch_name, worktree_path, "HEAD"],
+        cwd=project_cwd,
+        stdout=sys.stderr,
+        stderr=sys.stderr,
+    )
+    if result.returncode != 0:
+        print(
+            f"create_worktree_from_head: git worktree add failed for {worktree_path}",
+            file=sys.stderr,
+        )
+        return result.returncode
+
+    print(worktree_path)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "hooks": {
+    "WorktreeCreate": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"$CLAUDE_PROJECT_DIR\"/.claude/hooks/create_worktree_from_head.py"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ data/cache/
 *.parquet
 .ipynb_checkpoints/
 .DS_Store
+.claude/worktrees/
+.claude/settings.local.json

--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -1,0 +1,9 @@
+# Gitignored files to auto-copy into subagent worktrees.
+# Gitignore syntax. Only matches files that are BOTH listed here AND gitignored
+# get copied (tracked files are never duplicated).
+#
+# Purpose: let coding agents access .env (FRED_API_KEY, etc.) so they can run
+# scripts/fetch_data.py and verify against real data. Without this, agents
+# either skip verification or violate the "report-don't-patch" rule by copying
+# .env in manually.
+.env

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,6 +141,20 @@ subagents and reviewed before merging.
 isolated copy of the repo. This prevents conflicts with files the coordinator or user
 has open, and produces a clean diff to review before merging.
 
+Claude Code's default is to branch worktrees from `origin/HEAD` (i.e., main),
+regardless of which branch the coordinator is on. That's wrong for our flow —
+when the coordinator delegates from a feature branch with in-progress spec
+updates, the agent must see those updates. This project installs a
+`WorktreeCreate` hook at `.claude/hooks/create_worktree_from_head.py` that
+overrides the default and branches from the coordinator's current HEAD. Wired
+up in `.claude/settings.json` (committed). Result: delegation from any branch
+produces a worktree based at that branch's tip.
+
+`.env` is auto-copied into each subagent worktree via `.worktreeinclude`
+(committed). Agents must NOT copy `.env` manually or otherwise modify config to
+escape the worktree boundary — the copy is the sanctioned mechanism and needs
+no action from the agent.
+
 **Worktree testing boundary:** Worktrees have a clean checkout but no populated
 `data/` directory (parquet cache is gitignored and lives in the main repo). This means:
 - **Tests using synthetic/fixture data** run fine in a worktree — prefer these for
@@ -148,14 +162,14 @@ has open, and produces a clean diff to review before merging.
 - **Tests that read real cached data** (e.g., loading fetched FRED/Yahoo parquet
   files) will not find the cache and should either skip gracefully or be run by
   the coordinator in the main repo after the agent reports.
-- **`scripts/fetch_data.py`** cannot be run from a worktree without the `.env`
-  file and network. If an agent needs coverage numbers or verification that
-  requires the full fetch, it must **report this back to the coordinator**
-  rather than work around it.
+- **`scripts/fetch_data.py`** can be run from a worktree (since `.env` is
+  auto-copied via `.worktreeinclude`), but will fetch into the worktree's own
+  `data/` directory — not the main cache. Agents needing cache verification
+  should still report back rather than re-fetching.
 
-Agents must NOT modify config, copy environment variables into the worktree, or
-change paths to escape the worktree boundary. If tests or scripts can't run from
-the worktree, that's a scope signal — report it, don't patch around it.
+Agents must NOT modify config or change paths to escape the worktree boundary.
+If tests or scripts can't run from the worktree, that's a scope signal — report
+it, don't patch around it.
 
 **Background by default:** Coding agents should run with `run_in_background: true`
 when the task is well-specified. The spec is the contract — if the spec is complete,


### PR DESCRIPTION
## Summary

Root cause investigation of the stale-base worktrees we hit during the #1 cycle. Per Claude Code docs: `isolation: "worktree"` branches from `origin/HEAD` (= main) by design, regardless of which branch the coordinator is on. Documented behavior, not a bug. Agents 2 and 3 during #1 got worktrees missing the coordinator's spec updates for that reason.

**Two sanctioned fixes**, implemented together:

### WorktreeCreate hook
`.claude/hooks/create_worktree_from_head.py` replaces the default with `git worktree add -b worktree-<name> <path> HEAD`. New worktrees now branch from the coordinator's current HEAD. Named branch preserved so agent commits stay retrievable.

Python stdlib only — cross-platform (macOS/Linux/Windows). Chose Python over bash because `bash + jq` requires Git Bash on Windows, while Python 3.11+ is already a project dep.

### `.worktreeinclude`
Auto-copies `.env` into each subagent worktree, so agents can run `scripts/fetch_data.py` against real FRED data without manually copying `.env` — which the "report-don't-patch" rule in CLAUDE.md forbids. The `.worktreeinclude` mechanism is the sanctioned way to surface gitignored config to worktrees.

## Files
- `.claude/hooks/create_worktree_from_head.py` — the hook (new)
- `.claude/settings.json` — wires the hook up (committed, team-wide)
- `.worktreeinclude` — copies `.env` (committed)
- `.gitignore` — adds `.claude/worktrees/` and `.claude/settings.local.json`
- `CLAUDE.md` — documents the hook and the `.env` auto-copy; updates worktree testing boundary to reflect that `scripts/fetch_data.py` CAN now run in a worktree

## Smoke test
Ran the hook with a fabricated JSON payload — produced a worktree at `/tmp/test-worktree-hook` on branch `worktree-hook-smoke-test`, based at the current HEAD. Cleaned up.

## Tradeoff flagged earlier
The hook is in committed `.claude/settings.json` (not `.local.json`), so anyone cloning picks it up. Given this is a solo research project where "branch from current HEAD" is the intended norm, this is the right place.

## Test plan
- [ ] Next agent delegation from a feature branch produces a worktree that contains the branch's intermediate commits (not main's tip)
- [ ] Agent can run `scripts/fetch_data.py` without copying `.env` (because `.env` is pre-populated in the worktree)

## Follow-up
- Closes the investigation owed from PR #19's discussion
- Issue #18 (testing spec) still open; unblocked by this since agents can now run tests against real data

🤖 Generated with [Claude Code](https://claude.com/claude-code)