### PR TITLE
Fix: make worktree_name optional in WorktreeCreate hook

### DIFF
--- a/.claude/hooks/create_worktree_from_head.py
+++ b/.claude/hooks/create_worktree_from_head.py
@@ -19,6 +19,7 @@ Cross-platform: stdlib only, no jq or bash required.
 from __future__ import annotations
 
 import json
+import os
 import subprocess
 import sys
 
@@ -31,14 +32,19 @@ def main() -> int:
         return 1
 
     worktree_path = payload.get("worktree_path")
-    worktree_name = payload.get("worktree_name")
     project_cwd = payload.get("cwd")
-    if not worktree_path or not project_cwd or not worktree_name:
+    if not worktree_path or not project_cwd:
         print(
-            "create_worktree_from_head: payload missing worktree_path, worktree_name, or cwd",
+            "create_worktree_from_head: payload missing worktree_path or cwd. "
+            f"Keys received: {sorted(payload.keys())}",
             file=sys.stderr,
         )
         return 1
+
+    # worktree_name may or may not be present depending on how the worktree is
+    # being created. Fall back to deriving it from the path's final component so
+    # the branch always has a name.
+    worktree_name = payload.get("worktree_name") or os.path.basename(worktree_path)
 
     # Match Claude Code's default branch-naming convention (worktree-<name>).
     # Without -b, the worktree is detached-HEAD and any commits the agent


### PR DESCRIPTION
## Summary

The `WorktreeCreate` hook from #20 rejected any payload without `worktree_name`, but that field is only set for user-invoked `claude --worktree <name>` — for subagent worktrees (via `isolation: "worktree"`), the payload doesn't include it. Result: every agent delegation after #20 failed at worktree creation with `create_worktree_from_head: payload missing worktree_path, worktree_name, or cwd`.

## Fix
- `worktree_name` is now optional; derive from `os.path.basename(worktree_path)` when absent
- Error message when `worktree_path` or `cwd` is actually missing now includes the received keys, so future bugs are easier to diagnose

## Smoke test
```
$ echo '{"worktree_path": "/tmp/test-wt", "cwd": "'"$PWD"'"}' | python3 .claude/hooks/create_worktree_from_head.py
Preparing worktree (new branch 'worktree-test-wt')
HEAD is now at 2803491 Merge pull request #20 from dsdale24:docs/worktree-hook
/tmp/test-wt
```
Exit 0, named branch created, worktree based at current HEAD. Cleaned up.

## Test plan
- [ ] Next agent delegation with `isolation: "worktree"` creates a worktree successfully
- [ ] Worktree is based at the coordinator's current HEAD (not origin/HEAD)
- [ ] Worktree branch is named `worktree-<path-basename>`

Caught during the #18 testing-spec cycle — the first agent delegation after #20 merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)