### PR TITLE
Grant write permission inside subagent worktrees

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,11 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "permissions": {
+    "allow": [
+      "Edit(.claude/worktrees/**)",
+      "Write(.claude/worktrees/**)"
+    ]
+  },
   "hooks": {
     "WorktreeCreate": [
       {


### PR DESCRIPTION
## Summary

Subagents inherit the main instance's permission allowlist. The coordinator's allowlist in gitignored `.claude/settings.local.json` restricts Edit/Write to coordinator paths (docs/, configs/, CLAUDE.md) — enforcing the coordinator role. **Unintended side effect:** subagents in worktrees get Permission denied on code files because paths like `.claude/worktrees/<name>/pyproject.toml` don't match any allowlist entry.

Discovered when the #18 testing-spec implementation agent stopped with `Permission denied` on `pyproject.toml` in its worktree — correctly reporting instead of routing around with `cat > file`. The "report-don't-patch" rule worked as intended; this PR fixes the underlying config so the agent can proceed.

## Fix

Add to committed `.claude/settings.json`:

```json
"permissions": {
  "allow": [
    "Edit(.claude/worktrees/**)",
    "Write(.claude/worktrees/**)"
  ]
}
```

Worktrees are filesystem-isolated, so broad write permission inside them doesn't undermine the coordinator rule — the coordinator's own checkout of the main project remains restricted to its allowed paths.

Lives in `settings.json` (committed) rather than `settings.local.json` (personal) because this is a workflow requirement, not a per-user preference.

## Test plan
- [ ] Next subagent with `isolation: "worktree"` can Edit/Write files in its worktree without prompting
- [ ] Main instance still can't write `src/**` or `tests/**` (verify by trying — should prompt or deny per local settings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)