### PR TITLE
Fix subagent permissions: bare Edit/Write + per-user deny list

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,8 +2,8 @@
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
   "permissions": {
     "allow": [
-      "Edit(.claude/worktrees/**)",
-      "Write(.claude/worktrees/**)"
+      "Edit",
+      "Write"
     ]
   },
   "hooks": {


### PR DESCRIPTION
## Summary

PR #23's narrow `Edit(.claude/worktrees/**)` didn't work. Per the Claude Code permission docs, patterns without a leading `/` or `//` are CWD-relative (gitignore-style). A subagent's CWD is its worktree, so `.claude/worktrees/**` resolves to `<worktree>/.claude/worktrees/**` — a path that doesn't exist. The agent got "Permission to use Edit has been denied" and correctly stopped per report-don't-patch.

## The fix

Two-layer structure:

**Committed `.claude/settings.json`:** bare `Edit` and `Write` (no parens = match all uses). Subagents pick this up from the worktree's committed copy.

```json
"permissions": {
  "allow": ["Edit", "Write"]
}
```

**Personal `.claude/settings.local.json` (gitignored, not in worktree):** deny rules for paths the coordinator shouldn't touch.

```json
"permissions": {
  "deny": [
    "Edit(/src/**)", "Edit(/tests/**)", "Edit(/notebooks/**)",
    "Edit(/scripts/**)", "Edit(/data/**)", "Edit(/pyproject.toml)",
    "Write(/src/**)", ... (same paths)
  ],
  "allow": [ ...existing... ]
}
```

Rule precedence is `deny > ask > allow` across all scopes, so the main instance stays restricted (deny wins) while subagents — which don't read `settings.local.json` because it's not in their worktree — remain unrestricted within their worktree.

## Tradeoff

Subagents can theoretically edit anywhere in their worktree, not just a subpath. Since worktrees are filesystem-isolated from the main checkout, this is the right belt. The coordinator rule is now enforced by the deny list in `settings.local.json`, which is the actual suspender.

## Test plan
- [ ] Next subagent with `isolation: "worktree"` can Edit/Write files in its worktree without prompting
- [ ] Main instance prompts/denies when trying to edit `src/`, `tests/`, `pyproject.toml` (via the deny list)

This is the fourth workflow-infra PR surfaced by the #18 cycle. Each one was real — the surface area of the maker-checker flow is being hardened before it becomes a bottleneck.

🤖 Generated with [Claude Code](https://claude.com/claude-code)