### PR TITLE
Testing spec + pytest markers + CI workflow (fixes #18)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,19 @@
+name: tests
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install dependencies
+        run: pip install -e ".[dev]"
+      - name: Run tests
+        run: pytest -m "not integration"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,6 +30,12 @@ python scripts/fetch_data.py
 
 # Run notebooks
 cd notebooks && jupyter notebook
+
+# Tests (see docs/specs/testing_and_ci.md for full definitions)
+pytest                          # Everything (unit + integration + spec)
+pytest -m "not integration"     # Unit + spec-without-integration — CI, worktrees, quick feedback
+pytest -m integration           # Only tests that need the parquet cache — local, after fetching data
+pytest -m spec                  # Only spec-anchored tests — audit "what enforces this spec?"
 ```
 
 ## Architecture
@@ -170,6 +176,8 @@ no action from the agent.
 Agents must NOT modify config or change paths to escape the worktree boundary.
 If tests or scripts can't run from the worktree, that's a scope signal — report
 it, don't patch around it.
+
+For full test category definitions and CI design, see docs/specs/testing_and_ci.md.
 
 **Background by default:** Coding agents should run with `run_in_background: true`
 when the task is well-specified. The spec is the contract — if the spec is complete,

--- a/docs/specs/testing_and_ci.md
+++ b/docs/specs/testing_and_ci.md
@@ -1,0 +1,235 @@
+# Testing and CI Specification
+
+Status: **Stabilizing**
+Last updated: 2026-04-13
+
+## Purpose
+
+Define how tests are organized, when each category runs, and what CI enforces.
+Every specced component in this project depends on tests to verify its invariants;
+this document is what makes "stabilizing" mean "tested".
+
+## Scope
+
+- Test categories and pytest markers
+- Where each category can run (local, worktree, CI)
+- What CI's required check runs
+- How `@pytest.mark.spec` links tests to spec invariants
+- Worktree testing boundary (consolidated here; CLAUDE.md references this spec)
+
+What this spec does NOT cover: coverage thresholds, mutation testing,
+property-based testing, perf/benchmark tests, fixtures for specific components.
+
+## Test categories
+
+Three orthogonal markers. A test may have multiple (e.g., unit + spec).
+
+### `@pytest.mark.unit`
+
+**What it means:** The test uses synthetic fixtures only — no real data files, no
+network, no environment secrets. Runs in isolated tmp dirs. Finishes in under
+one second per test.
+
+**Can import:** project modules, pandas, pytest fixtures, synthetic DataFrames.
+
+**Cannot:** read `data/raw/**`, call FRED/Yahoo APIs, require `FRED_API_KEY`,
+write outside `tmp_path`, depend on wall-clock time.
+
+**Runs in:** worktrees, CI, local — everywhere.
+
+**Default for new tests.** If a test can be written as unit, it must be.
+
+### `@pytest.mark.integration`
+
+**What it means:** The test reads the real parquet cache at `data/raw/` or
+otherwise depends on state the worktree doesn't have.
+
+**Can:** read `data/raw/**/*.parquet`, use cached FRED/Yahoo data.
+
+**Cannot:** call external APIs directly (write an ad-hoc fetch script in
+`scripts/` if needed, don't bake network calls into tests).
+
+**Must:** skip gracefully when the cache is absent, via the `require_cache`
+fixture (see "Conftest helpers" below). Skipping is **required** — a test that
+errors instead of skips on a missing cache is a bug in the test.
+
+**Runs in:** local only. Not in CI (no cache strategy). Not in worktrees by
+default — if an agent needs integration verification, it reports back rather
+than running.
+
+### `@pytest.mark.spec`
+
+**What it means:** The test directly verifies an invariant or test case listed
+in a `docs/specs/*.md` file. Orthogonal to unit/integration — most `spec` tests
+are also `unit`, but some are `integration`.
+
+**Required:** the test's docstring must reference the spec and the specific
+invariant or test case. Example:
+
+```python
+@pytest.mark.unit
+@pytest.mark.spec
+def test_spliced_gold_monthly_returns_match_proxy(...):
+    """docs/specs/backtester.md "Proxy series splicing → Test cases":
+    compounded monthly returns from spliced daily gold series equal
+    WPUSI019011 monthly returns for any full month in 1975-2000."""
+```
+
+**Purpose:** discoverability. `pytest -m spec` lists every test that's
+load-bearing for a spec — useful for the review agent in #15 and for humans
+auditing whether a spec is covered.
+
+## Invariants
+
+- Every test file has at least one marker applied to every test. An unmarked
+  test is a lint failure (enforced via the conftest check below).
+- A test marked `integration` without also using `require_cache` is a test bug.
+- A test marked `spec` without a docstring referencing the spec is a test bug.
+- `unit` and `integration` are mutually exclusive — a test cannot be both.
+
+## Test invocation
+
+| Command | What runs | Where to use it |
+|---|---|---|
+| `pytest` | Everything (unit + integration + spec) | Local dev, full confidence run |
+| `pytest -m "not integration"` | Unit + spec-without-integration | CI, worktrees, quick feedback |
+| `pytest -m integration` | Only tests that need the parquet cache | Local, after fetching data |
+| `pytest -m spec` | Only spec-anchored tests | Audit: "what enforces this spec?" |
+
+CI runs `pytest -m "not integration"`. Everything except integration is a
+required check.
+
+## Conftest helpers
+
+### `require_cache` fixture
+
+In `tests/conftest.py`:
+
+```python
+import pytest
+from pathlib import Path
+
+DATA_RAW = Path(__file__).parent.parent / "data" / "raw"
+
+@pytest.fixture
+def require_cache():
+    """Skip the test if the FRED/Yahoo parquet cache is not populated.
+    Integration tests depend on real cached data; worktrees and CI typically
+    don't have it."""
+    if not DATA_RAW.exists() or not any(DATA_RAW.rglob("*.parquet")):
+        pytest.skip("parquet cache at data/raw/ not populated — run scripts/fetch_data.py")
+```
+
+Integration tests MUST depend on this fixture (`def test_foo(require_cache):`)
+so they skip cleanly instead of failing with FileNotFoundError.
+
+### Unmarked-test lint (in `conftest.py`)
+
+```python
+_ALLOWED_MARKERS = {"unit", "integration", "spec"}
+
+def pytest_collection_modifyitems(config, items):
+    unmarked = [
+        item for item in items
+        if not any(m.name in _ALLOWED_MARKERS for m in item.iter_markers())
+    ]
+    if unmarked:
+        names = "\n  ".join(item.nodeid for item in unmarked)
+        raise pytest.UsageError(
+            f"Tests missing a required marker (unit|integration|spec):\n  {names}"
+        )
+```
+
+This runs at collection time. Adding a test without a marker fails the suite
+before any test runs.
+
+## pyproject.toml configuration
+
+```toml
+[tool.pytest.ini_options]
+markers = [
+  "unit: synthetic fixtures only; runs in worktrees and CI",
+  "integration: uses real data/raw/ parquet cache; local only, skips if absent",
+  "spec: directly verifies an invariant listed in docs/specs/*.md",
+]
+testpaths = ["tests"]
+# Fail the run if any test uses an unregistered marker.
+# Combined with the collection check above, forces marker discipline.
+addopts = ["--strict-markers"]
+```
+
+## Worktree testing boundary
+
+Subagent worktrees have:
+- A fresh checkout of the repo
+- `.env` auto-copied via `.worktreeinclude` (so `scripts/fetch_data.py` can run
+  in principle — but it would fetch into the worktree's own `data/`, not the
+  main cache)
+- NO populated `data/raw/` parquet cache
+
+Consequences for agents:
+- `pytest -m "not integration"` runs fine — same as CI
+- `pytest -m integration` will skip every integration test (cache absent). That
+  is correct behavior, not a failure.
+- If an agent needs integration-level verification (e.g., a compounding identity
+  check against real FRED data), it reports back rather than re-fetching. Per
+  CLAUDE.md "Reporting is success, workarounds are failure".
+
+The coordinator runs integration tests in the main repo after the agent returns.
+
+## CI job design
+
+Platform: GitHub Actions.
+
+Workflow file: `.github/workflows/tests.yml`.
+
+Required steps:
+1. Checkout
+2. Setup Python 3.11+
+3. Install dev dependencies (`pip install -e ".[dev]"`)
+4. Run `pytest -m "not integration"`
+
+CI must not require `FRED_API_KEY`, network access to FRED/Yahoo, or the parquet
+cache. Any of those is a test-categorization bug (the test should be
+`integration`, not `unit`).
+
+### Not in scope for the initial CI
+- Coverage reporting
+- Ruff or formatter checks (separate workflow when we add them)
+- Matrix across Python versions (3.11 is the floor; cross-version later if
+  we see breakage)
+- Caching pip dependencies (add when install time exceeds 30 seconds)
+
+## Test cases (for this spec)
+
+Yes, this spec's own rules are testable. The conftest check above is effectively
+the test for "every test has a marker". Additional invariants:
+
+- `pytest -m "not integration"` from a fresh worktree (no `data/raw/`) exits 0
+  with the existing test suite — no skips that look like failures.
+- Adding a new test file without any marker causes `pytest` to fail at
+  collection (not error at runtime).
+- Adding a test with `@pytest.mark.unknown` fails at collection because of
+  `--strict-markers`.
+
+## Migration checklist (for the initial implementation)
+
+1. Add `[tool.pytest.ini_options]` to `pyproject.toml` with markers and
+   `--strict-markers`.
+2. Add `require_cache` fixture and collection hook to `tests/conftest.py`.
+3. Mark every test in `tests/test_proxy_splicing.py` as `@pytest.mark.unit`.
+   Mark the four that directly verify a spec's test case as `@pytest.mark.spec`
+   as well, and ensure their docstrings reference `docs/specs/backtester.md`.
+4. Create `.github/workflows/tests.yml` running `pytest -m "not integration"`.
+5. Update `CLAUDE.md` "Setup & commands" with the four `pytest` invocations
+   above, and update "Worktree testing boundary" to reference this spec.
+
+## What this spec does NOT cover
+
+- Coverage thresholds (add later if overfitting to covered code becomes a
+  problem)
+- Mutation testing (nice-to-have, not essential)
+- Property-based testing with hypothesis (fine to adopt ad-hoc in `unit`
+  tests when useful; no blanket policy)
+- Perf/benchmark tests (separate concern; no marker yet)
+- Snapshot testing

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,3 +17,14 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = ["ruff", "pytest"]
+
+[tool.pytest.ini_options]
+markers = [
+  "unit: synthetic fixtures only; runs in worktrees and CI",
+  "integration: uses real data/raw/ parquet cache; local only, skips if absent",
+  "spec: directly verifies an invariant listed in docs/specs/*.md",
+]
+testpaths = ["tests"]
+# Fail the run if any test uses an unregistered marker.
+# Combined with the collection check above, forces marker discipline.
+addopts = ["--strict-markers"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,34 @@
 import sys
 from pathlib import Path
 
+import pytest
+
 ROOT = Path(__file__).resolve().parent.parent
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
+
+DATA_RAW = Path(__file__).parent.parent / "data" / "raw"
+
+
+@pytest.fixture
+def require_cache():
+    """Skip the test if the FRED/Yahoo parquet cache is not populated.
+    Integration tests depend on real cached data; worktrees and CI typically
+    don't have it."""
+    if not DATA_RAW.exists() or not any(DATA_RAW.rglob("*.parquet")):
+        pytest.skip("parquet cache at data/raw/ not populated — run scripts/fetch_data.py")
+
+
+_ALLOWED_MARKERS = {"unit", "integration", "spec"}
+
+
+def pytest_collection_modifyitems(config, items):
+    unmarked = [
+        item for item in items
+        if not any(m.name in _ALLOWED_MARKERS for m in item.iter_markers())
+    ]
+    if unmarked:
+        names = "\n  ".join(item.nodeid for item in unmarked)
+        raise pytest.UsageError(
+            f"Tests missing a required marker (unit|integration|spec):\n  {names}"
+        )

--- a/tests/test_proxy_splicing.py
+++ b/tests/test_proxy_splicing.py
@@ -102,8 +102,11 @@ def synthetic_data(trading_index: pd.DatetimeIndex) -> dict:
 # Monthly -> daily conversion invariant
 # ---------------------------------------------------------------------------
 
+@pytest.mark.unit
+@pytest.mark.spec
 def test_monthly_to_daily_compounding_identity():
-    """Compounded daily returns equal the underlying monthly return."""
+    """docs/specs/backtester.md "Proxy series splicing → Test cases":
+    compounded daily returns equal the underlying monthly return."""
     idx = _business_days("1980-01-01", "1980-12-31")
     levels = pd.Series(
         [100.0, 101.0, 99.5, 102.3, 103.0, 104.1, 106.0, 105.5, 107.0,
@@ -125,6 +128,7 @@ def test_monthly_to_daily_compounding_identity():
         )
 
 
+@pytest.mark.unit
 def test_monthly_to_daily_evenly_distributed():
     """Within a month, every trading day receives the same daily return."""
     idx = _business_days("1980-02-01", "1980-02-29")
@@ -142,7 +146,11 @@ def test_monthly_to_daily_evenly_distributed():
 # Splice invariants: no gap / no overlap
 # ---------------------------------------------------------------------------
 
+@pytest.mark.unit
+@pytest.mark.spec
 def test_splice_has_no_overlap_and_no_gap(synthetic_data):
+    """docs/specs/backtester.md "Proxy series splicing → Test cases":
+    spliced series have no gap or overlap at splice boundaries."""
     returns, sources = build_asset_returns(
         synthetic_data, start="1975-01-01", return_sources=True
     )
@@ -190,8 +198,11 @@ def test_splice_has_no_overlap_and_no_gap(synthetic_data):
     assert sources.loc[wti_prev, "commodities"] != sources.loc[wti_to_fut, "commodities"]
 
 
+@pytest.mark.unit
+@pytest.mark.spec
 def test_commodities_splice_boundary(synthetic_data):
-    """The day before each splice belongs to the older source; the day of, to the newer."""
+    """docs/specs/backtester.md "Proxy series splicing → Test cases":
+    the day before each splice belongs to the older source; the day of, to the newer."""
     _, sources = build_asset_returns(
         synthetic_data, start="1975-01-01", return_sources=True
     )
@@ -205,8 +216,11 @@ def test_commodities_splice_boundary(synthetic_data):
 # Non-zero returns pre-2000
 # ---------------------------------------------------------------------------
 
+@pytest.mark.unit
+@pytest.mark.spec
 def test_nonzero_returns_for_gold_and_commodities_in_1975(synthetic_data):
-    """At 1975-06-15, gold and commodities must have real (non-zero) returns."""
+    """docs/specs/backtester.md "Proxy series splicing → Test cases":
+    at 1975-06-15, gold and commodities must have real (non-zero) returns."""
     returns = build_asset_returns(synthetic_data, start="1975-01-01")
 
     target = pd.Timestamp("1975-06-15")
@@ -222,9 +236,12 @@ def test_nonzero_returns_for_gold_and_commodities_in_1975(synthetic_data):
 # Spliced gold returns reproduce WPUSI019011 monthly returns
 # ---------------------------------------------------------------------------
 
+@pytest.mark.unit
+@pytest.mark.spec
 def test_spliced_gold_monthly_returns_match_proxy(synthetic_data):
-    """For any full month in 1975-2000, compounded daily gold returns equal
-    WPUSI019011 monthly returns."""
+    """docs/specs/backtester.md "Proxy series splicing → Test cases":
+    compounded monthly returns from spliced daily gold series equal
+    WPUSI019011 monthly returns for any full month in 1975-2000."""
     returns = build_asset_returns(synthetic_data, start="1975-01-01")
 
     wpu = synthetic_data[GOLD_PROXY_SERIES]
@@ -256,6 +273,7 @@ def test_spliced_gold_monthly_returns_match_proxy(synthetic_data):
 # splice_returns primitive: newer source wins on overlap
 # ---------------------------------------------------------------------------
 
+@pytest.mark.unit
 def test_splice_returns_newer_wins():
     idx_a = pd.date_range("2000-01-01", periods=5, freq="D")
     idx_b = pd.date_range("2000-01-04", periods=5, freq="D")


### PR DESCRIPTION
## Summary

Closes #18. Stabilizes testing practice before Phase 3a continues (#8 bonds, #6 transaction costs) and before #15 Level 2 Claude review is designed.

### Spec (`docs/specs/testing_and_ci.md`)
Three orthogonal markers:
- `unit` — synthetic fixtures, runs everywhere (worktrees, CI)
- `integration` — reads `data/raw/` parquet cache, local-only, skips if absent via `require_cache` fixture
- `spec` — verifies a `docs/specs/*.md` invariant (often unit+spec; sometimes integration+spec)

CI command: `pytest -m "not integration"` on GitHub Actions, Python 3.11, ubuntu-latest.

Includes a `pytest_collection_modifyitems` hook that fails at collection if any test is unmarked — forces marker discipline rather than relying on convention.

### Implementation
- `pyproject.toml` — `[tool.pytest.ini_options]` with markers registered + `--strict-markers`
- `tests/conftest.py` — `require_cache` fixture and unmarked-test collection hook (preserves existing `sys.path` block)
- `tests/test_proxy_splicing.py` — all 7 tests marked `@pytest.mark.unit`; 5 of them also `@pytest.mark.spec` with docstrings referencing `docs/specs/backtester.md`
- `.github/workflows/tests.yml` — minimal CI: checkout → Python 3.11 → `pip install -e ".[dev]"` → `pytest -m "not integration"`
- `CLAUDE.md` — four pytest invocations in "Setup & commands"; reference line in "Worktree testing boundary"

### Verification (coordinator-run locally)
- `pytest -m "not integration"` → 7 passed
- `pytest -m spec` → 5 passed, 2 deselected
- `pytest -m integration` → 0 selected, 7 deselected

### Workflow-infra fixes landed along the way
This cycle surfaced four real workflow bugs, all separately PR'd and merged:
- #21 — WorktreeCreate hook: `worktree_name` optional
- #22 — Handle subagent WorktreeCreate payload shape (uses `name`, not `worktree_name`)
- #23 — Initial attempt at subagent worktree write permissions (narrow pattern; didn't work)
- #24 — Correct subagent permissions via bare `Edit`/`Write` + per-user deny list

Each was a genuine bug exposed by running the maker-checker flow end-to-end. The flow is now much more solid for future cycles.

### Follow-ups unblocked
- #15 Level 2 (CI-integrated Claude review) — now has a CI job to hook into
- Upstream docs feedback already filed to Claude Code: WorktreeCreate schema is out of date

## Test plan
- [x] `pytest -m "not integration"` — 7/7 pass
- [x] `pytest -m spec` — 5 selected, all pass
- [x] `pytest -m integration` — 0 selected (no integration tests yet)
- [ ] Next `stable/*` PR: author adds `@pytest.mark.spec` to any new spec-anchored tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)