### PR TITLE
Level 1 review agent: reusable prompt + /review-pr slash command (#15)

### DIFF
--- a/.claude/commands/review-pr.md
+++ b/.claude/commands/review-pr.md
@@ -1,0 +1,34 @@
+---
+description: Pre-merge review agent — verifies a PR against its specs before you merge
+---
+
+Run a pre-merge review of PR #$ARGUMENTS using the canonical prompt at
+`docs/review_agent_prompt.md`.
+
+Steps to take:
+
+1. Read `docs/review_agent_prompt.md` so you know the current prompt
+   (it may have been tuned since the last review).
+
+2. Identify the relevant specs by running `gh pr view $ARGUMENTS` and
+   checking:
+   - Which files the PR touches (diff)
+   - Whether the PR body mentions specific specs
+   - For each modified file in `src/` or `tests/`, which `docs/specs/*.md`
+     governs it (see the "Current spec status" table in CLAUDE.md)
+
+3. Spawn a foreground general-purpose agent with the prompt from
+   `docs/review_agent_prompt.md`, filling in:
+   - `<PR_NUMBER>` = $ARGUMENTS
+   - `<RELEVANT_SPECS>` = the specs identified in step 2
+
+4. When the agent returns its verdict:
+   - PASS → ask the user if they want to merge
+   - PASS-WITH-NITS → summarize the nits and ask the user if they want to
+     merge or fix first
+   - CHANGES-REQUIRED → summarize the blocking issues; do NOT offer to
+     merge; delegate a coding agent to fix or ask the user to redirect
+   - BLOCKED → report what's blocked and ask the user how to proceed
+
+Do NOT merge the PR yourself based on the verdict alone. The human makes
+the merge decision; your job is to surface the review findings.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,7 +141,8 @@ subagents and reviewed before merging.
 4. Coordinator delegates to a review agent to check implementation against spec
 5. Coordinator reviews findings, approves or sends back
 6. Coordinator pushes the branch and opens a pull request (never merges locally to main)
-7. Work is landed by merging the PR — this preserves a reviewable artifact, keeps a searchable history, and gives the review agent (see issue #15) a surface to hook into
+7. Before merging, coordinator runs a **pre-merge review** of the PR — either via `/review-pr <number>` (which uses the canonical prompt at `docs/review_agent_prompt.md`) or by spawning a review agent manually. Merge only on PASS or PASS-WITH-NITS (see #15 for the Level 1/2/3 escalation path toward CI enforcement)
+8. Work is landed by merging the PR — this preserves a reviewable artifact, keeps a searchable history, and gives CI and the review agent a surface to hook into
 
 **Worktrees:** Coding agents should use `isolation: "worktree"` so they work on an
 isolated copy of the repo. This prevents conflicts with files the coordinator or user

--- a/docs/review_agent_prompt.md
+++ b/docs/review_agent_prompt.md
@@ -1,0 +1,155 @@
+# PR Review Agent — Reusable Prompt Template
+
+Canonical prompt for the pre-merge review agent described in issue #15
+Level 1. Copy this into an `Agent(subagent_type="general-purpose", ...)`
+call before running `gh pr merge`, filling in the placeholders.
+
+Status: **Exploring**. The template will change as we learn what catches
+real issues and what's noise. Update this file when you adjust the prompt
+mid-review — don't drift silently.
+
+## When to use
+
+Before merging any PR, especially:
+- PRs from `stable/*` branches (touches a specced component)
+- PRs from `fix/*` branches on specced components
+- Any PR that adds or modifies tests
+
+OK to skip:
+- Pure `docs/*` changes that don't touch specs or workflow rules
+- Reverting an obviously-bad commit
+
+## Usage
+
+Fill in the placeholders:
+- `<PR_NUMBER>` — the PR under review (e.g., `25`)
+- `<RELEVANT_SPECS>` — list of `docs/specs/*.md` files the PR should conform to
+- `<COMMIT_RANGE>` — optional; the commit range if the PR's worth reviewing commit-by-commit
+
+Then spawn the agent (foreground — coordinator needs the verdict before merging):
+
+```
+Agent(
+  description="Pre-merge review for PR #<PR_NUMBER>",
+  subagent_type="general-purpose",
+  prompt=<<contents of the prompt section below, with placeholders filled>>
+)
+```
+
+## The prompt
+
+```
+You are a pre-merge review agent for a spec-driven research project using
+the maker-checker workflow described in CLAUDE.md. Your job: independently
+verify that PR #<PR_NUMBER> matches the spec(s) it claims to conform to,
+and produce a verdict. You do NOT modify files. Your output is a written
+review only.
+
+## Project context
+
+Macro backtesting research project. Specs live in `docs/specs/*.md` and
+are authoritative for components marked Stabilizing or Settled (see the
+"Current spec status" table in CLAUDE.md). The maker-checker flow:
+spec is written first, coding agent implements, review agent (you) checks
+against the spec.
+
+## Inputs
+- PR number: #<PR_NUMBER>
+- Relevant specs to verify against: <RELEVANT_SPECS>
+- Project root: the current repo
+
+Fetch the PR metadata and diff:
+  gh pr view <PR_NUMBER>
+  gh pr diff <PR_NUMBER>
+
+Read each relevant spec file in full before evaluating conformance.
+
+## What to verify
+
+### 1. Spec conformance
+For each spec listed in <RELEVANT_SPECS>:
+- Does the diff implement the spec's invariants?
+- If the spec has a "Test cases" section, are each of those cases covered
+  by a test in the diff (new or existing)?
+- If the PR updates the spec, does the implementation conform to the
+  updated spec, not the old version?
+
+### 2. Test quality (read the tests, not just the test names)
+For any new or changed tests:
+- Do the assertions actually verify what the test name says?
+- Would a broken implementation — one that violated the spec — actually
+  FAIL these tests? A test that passes against any input is decorative.
+- Are spec-anchored tests (`@pytest.mark.spec`) referencing their spec
+  section in the docstring per `docs/specs/testing_and_ci.md`?
+
+### 3. Scope discipline
+- Does the diff touch only files that the task required?
+- Any unrelated refactoring, style changes, or drive-by edits?
+- If the PR is labeled `fix/*`, is the fix narrow or has it expanded?
+- If the PR touches a specced component, does it reference the spec in
+  the commit message or PR description?
+
+### 4. Code quality (only surface real issues, not nits)
+- PEP 8 / PEP 257 / PEP 484 per CLAUDE.md's code standards
+- Type hints on new function signatures
+- Docstrings on new helpers explaining the *why*
+- No obvious dead code or unnecessary comments
+
+### 5. Spec regressions
+If the PR modifies a spec:
+- Is the change additive (new invariant) or a loosening (removed invariant)?
+- If loosening, is there justification in the PR or commit message?
+- If the PR modifies implementation and also tightens the spec to match
+  (rather than loosening the spec to accept the implementation), that's
+  the healthy direction. Flag the inverse.
+
+## Effort budget
+
+Roughly 10-15 tool calls. If you exceed 25 without a clear verdict, STOP
+and report what's taking longer than expected. Do NOT modify any files.
+Do NOT push or merge. Do NOT run the tests unless necessary to verify a
+specific claim (and report if you do — it's the coordinator's job).
+
+## Report format (under 400 words)
+
+Start with a **Verdict** line, one of:
+- `PASS` — ready to merge as-is
+- `PASS-WITH-NITS` — mergeable, but list the small issues to clean up later
+- `CHANGES-REQUIRED` — real spec deviations or broken tests; list them
+- `BLOCKED` — couldn't verify something important; say what
+
+Then **Findings**, grouped by severity:
+- **Critical** — merge is unsafe as-is (breaks an invariant, fails tests)
+- **Major** — spec deviation or test-quality issue that should block merge
+- **Minor** — real issue that's OK to land and fix in a follow-up
+- **Nit** — style/taste, not worth a round-trip
+
+For each finding: `file:line — what you found — why it matters relative
+to the spec`.
+
+If applicable, a **Spec→test coverage matrix**: for each test case in the
+relevant spec, one line:
+`<spec test case phrasing> — <test function name> — VERIFIED | WEAK | MISSING`
+
+Do not recommend changes unless they're required to meet the spec. This is
+a spec-conformance review, not a code-improvement session.
+```
+
+## Notes on running this
+
+- **Foreground, not background.** The coordinator needs the verdict
+  before deciding whether to merge.
+- **PR must already be open.** Push the branch and open the PR first;
+  the agent reads the PR via `gh` rather than a local branch.
+- **Skip if the PR is purely docs and doesn't touch specs or workflow
+  rules.** Overhead isn't worth it.
+- **Update this file when you adjust the prompt mid-cycle.** Otherwise
+  the next review drifts from the last and you lose continuity.
+
+## Follow-up levels (see #15)
+
+- **Level 2** — GitHub Actions that runs this as a PR check automatically
+- **Level 3** — Required-status-check enforcement via branch protection
+
+Level 1 → Level 2 promotion criteria: the prompt has been used on 3+ PRs
+and the false-positive rate is acceptable.


### PR DESCRIPTION
## Summary

First pass at #15 Level 1 — pre-merge Claude-in-the-loop review. No CI infra yet; this is the lightest-weight version that lives entirely in the local coordinator session. Exploring-phase work, no spec required.

### What lands
1. **`docs/review_agent_prompt.md`** — canonical prompt template with project context, verification focus areas (spec conformance, test quality, scope discipline, code quality, spec-regression direction), verdict taxonomy, findings-by-severity format, and spec→test coverage matrix. Iterative; update the file when you tune the prompt.

2. **`.claude/commands/review-pr.md`** — `/review-pr <number>` slash command that walks the coordinator through:
   - Reading the current prompt template
   - Identifying relevant specs via `gh pr view` + the spec-status table in CLAUDE.md
   - Spawning a foreground review agent with the right context
   - Interpreting the verdict (PASS → ask to merge; PASS-WITH-NITS → summarize nits and ask; CHANGES-REQUIRED → delegate a fix; BLOCKED → report)

   Never auto-merges; the human always decides.

3. **CLAUDE.md maker-checker flow** — step 7 is now "run a pre-merge review before merging" (was previously implied by step 6). Merge only on PASS or PASS-WITH-NITS.

### What's still open in #15
- **Level 2** — GitHub Actions check that runs this automatically on every PR
- **Level 3** — Required-status-check via branch protection

Promotion criterion from Level 1 to Level 2: the prompt has been used on 3+ real PRs and the false-positive rate is acceptable. Dogfood on the next 3 PRs, then invest in Actions infra.

### Dogfood note

I have not used `/review-pr` on THIS PR because chicken-and-egg: the prompt template it'd use is what's being added. First real test will be the next stable/* PR.

## Test plan
- [ ] Next `stable/*` PR: run `/review-pr <number>` before merging and verify the verdict
- [ ] Update `docs/review_agent_prompt.md` if the prompt produces obvious noise or misses real issues
- [ ] Track "used on N PRs" toward the Level 2 promotion criterion

🤖 Generated with [Claude Code](https://claude.com/claude-code)