### PR TITLE
Grant subagents Bash permission for standard project tools

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -3,7 +3,13 @@
   "permissions": {
     "allow": [
       "Edit",
-      "Write"
+      "Write",
+      "Bash(git:*)",
+      "Bash(pytest:*)",
+      "Bash(python -m pytest:*)",
+      "Bash(python scripts/*:*)",
+      "Bash(python3 scripts/*:*)",
+      "Bash(pip install:*)"
     ]
   },
   "hooks": {


### PR DESCRIPTION
## Summary

Subagents read `.claude/settings.json` (committed) but not `settings.local.json` (gitignored, not in worktree). The settings.json from #24 had only bare `Edit` and `Write` — no Bash entries — so subagents inherited "ask" mode for Bash, which auto-denies for agents (they can't prompt).

The bond-validation agent for #8 hit this:
- `python scripts/fetch_data.py` worked (specifically allowlisted in the coordinator's `settings.local.json`)
- `python scripts/validate_bond_returns.py` was denied (no allowlist entry matched)
- Agent correctly reported instead of laundering the call through `python -c`

## Fix

Add a focused Bash allowlist to committed `settings.json`:

```json
"Bash(git:*)",
"Bash(pytest:*)",
"Bash(python -m pytest:*)",
"Bash(python scripts/*:*)",
"Bash(python3 scripts/*:*)",
"Bash(pip install:*)"
```

`scripts/` is project-controlled code — a broad pattern there is safe and saves us from per-script-rule bookkeeping.

## Test plan
- [ ] Re-run the bond-validation agent on `stable/phase3a/bond-returns-validation` — `python scripts/validate_bond_returns.py` should now run without prompting
- [ ] Future test agents can run `pytest -m ...` without per-marker rules

🤖 Generated with [Claude Code](https://claude.com/claude-code)