### PR TITLE
Bond return approximation: spec + validation finding (closes #8)

### DIFF
--- a/configs/series.yaml
+++ b/configs/series.yaml
@@ -403,7 +403,13 @@ yahoo:
   "TLT":
     name: 20+ Year Treasury ETF
     category: bonds
-    description: iShares 20+ Year Treasury Bond ETF
+    description: iShares 20+ Year Treasury Bond ETF; used to validate synthetic long_bonds return approximation (see docs/specs/backtester.md)
+    start_override: "2002-07-01"
+
+  "SHY":
+    name: 1-3 Year Treasury ETF
+    category: bonds
+    description: iShares 1-3 Year Treasury Bond ETF; used to validate synthetic short_bonds return approximation (see docs/specs/backtester.md)
     start_override: "2002-07-01"
 
   "TIP":

--- a/docs/research/bond_return_validation.md
+++ b/docs/research/bond_return_validation.md
@@ -1,0 +1,112 @@
+# Bond Return Approximation Validation
+
+Date: 2026-04-14
+Issue: #8
+Spec: `docs/specs/backtester.md` §"Bond return approximation"
+Script: `scripts/validate_bond_returns.py`
+
+## Question
+
+Are the synthetic bond returns produced by `build_asset_returns()` accurate
+enough for fair strategy comparison?
+
+The synthetic returns use a first-order duration approximation:
+
+```
+daily_return = -duration × Δyield + yield_prev / 252
+```
+
+with `duration = 8` for `long_bonds` (10Y proxy, `^TNX`) and `duration = 2`
+for `short_bonds` (2Y proxy, `GS2`).
+
+## Method
+
+Compare synthetic monthly returns against real ETF total-return data over
+the available overlap (2002-07 → present):
+
+- `long_bonds` vs **TLT** (iShares 20+ Year Treasury Bond ETF)
+- `short_bonds` vs **SHY** (iShares 1-3 Year Treasury Bond ETF)
+
+Per spec, the approximation is adequate if **both** of these hold per asset:
+
+- Per-decade |CAGR divergence| ≤ 0.50 percentage points per year
+- Correlation of monthly returns ≥ 0.90
+
+If either bound is violated, the spec requires splicing the ETF data for
+the overlap period.
+
+## Result
+
+```
+asset       | decade | synthetic_CAGR | ETF_CAGR | divergence_ppt_per_yr | correlation
+------------+--------+----------------+----------+-----------------------+-------------
+long_bonds  | 2000s  | +4.94%         | +6.02%   | -1.08                 | 0.929
+long_bonds  | 2010s  | +3.81%         | +7.23%   | -3.42                 | 0.929
+long_bonds  | 2020s  | -0.33%         | -4.07%   | +3.74                 | 0.929
+short_bonds | 2000s  | +3.52%         | +3.31%   | +0.21                 | 0.771
+short_bonds | 2010s  | +0.85%         | +1.09%   | -0.25                 | 0.771
+short_bonds | 2020s  | +2.20%         | +1.83%   | +0.36                 | 0.771
+
+long_bonds vs TLT:  MAE(monthly) = 1.550%   corr = 0.929   FAIL
+short_bonds vs SHY: MAE(monthly) = 0.215%   corr = 0.771   FAIL
+```
+
+**Both assets fail the spec threshold:**
+
+- `long_bonds` correlation passes (0.929 ≥ 0.90), but per-decade CAGR divergence is **−1.08 / −3.42 / +3.74 ppt/yr** — far beyond the 0.50 ppt/yr bound. Worst is the 2010s (−3.42), where the synthetic understates by 3.4 ppt/yr; over the decade that compounds to roughly 30% of missing return.
+- `short_bonds` per-decade divergence is within tolerance (≤ 0.36 ppt/yr), but **correlation is only 0.771**, well below the 0.90 bound.
+
+## Interpretation
+
+The long_bonds error pattern is informative: synthetic **understates** in the
+2000s and 2010s (rates falling) and **overstates** in the 2020s (rates rising).
+That's the unmistakable signature of missing **convexity** — bond convexity
+contributes positive return when rates fall and negative return when they rise,
+and a pure duration model misses both.
+
+Convexity matters most for long-duration assets (~10-year duration here), so
+it's no surprise short_bonds shows a smaller per-decade error magnitude. The
+short_bonds correlation problem is likely from coupon roll/reinvestment effects
+that matter relatively more for short bonds (where the carry term dominates the
+price-change term).
+
+## Decision
+
+Per the spec ("If either bound is violated, the implementation must splice
+real ETF data for the overlap period"), both assets need ETF splicing:
+
+- **long_bonds**: splice TLT for `2002-07-30 → present`; keep duration
+  approximation for `1975 → 2002-07-29` (no alternative)
+- **short_bonds**: splice SHY for `2002-07-30 → present`; keep duration
+  approximation for `1975 → 2002-07-29`
+
+This is the same splicing pattern used for `gold` and `commodities` in #1.
+Implementation tracked separately so this PR stays focused on the validation
+result.
+
+## Open questions
+
+1. **Pre-2002 uncertainty.** The 1975-2002 window is exactly the period that
+   matters most for long-horizon backtests, and we have no ETF benchmark to
+   measure approximation error there. The convexity-bias pattern observed
+   2002+ is likely also present pre-2002. We should communicate this in
+   backtest outputs (e.g., flag pre-2002 bond returns as "approximation
+   only" in result metadata).
+
+2. **Should we also splice TIP for inflation-linked exposure?** TIP is
+   already in `configs/series.yaml`. Out of scope for #8; relevant if we add
+   TIPS as an asset class (#10).
+
+3. **Hybrid for the 1990s?** The 1990s aren't in the validation window
+   (TLT/SHY start 2002-07), but ICE BofA Treasury indices on FRED go back
+   further. Could expand the validation if precision matters more later.
+
+## Reproducing
+
+```bash
+source .venv/bin/activate
+python scripts/fetch_data.py     # ensures TLT and SHY are cached
+python scripts/validate_bond_returns.py
+```
+
+The script is deterministic and reads only cached parquet files.

--- a/docs/specs/backtester.md
+++ b/docs/specs/backtester.md
@@ -1,7 +1,7 @@
 # Backtester Specification
 
 Status: **Stabilizing**
-Last updated: 2026-04-13 (transaction costs added — see issue #6)
+Last updated: 2026-04-13 (bond return approximation validated — see issue #8)
 
 ## Purpose
 
@@ -72,6 +72,77 @@ Specifically:
   index.
 - Pre-data periods: covered by proxy splicing (see below). Any remaining gap must
   be explicitly documented.
+
+## Bond return approximation
+
+### Purpose
+Real bond total-return indices are not freely available for the full
+1975-present range. We approximate daily total returns from Treasury
+yields using a first-order duration model.
+
+### Formula
+For each trading day `t`:
+```
+daily_return[t] = -duration × (yield[t] - yield[t-1]) + yield[t-1] / 252
+```
+- `yield` is in decimal form (0.05 = 5%)
+- `duration = 8` for `long_bonds` (10Y proxy, `^TNX`)
+- `duration = 2` for `short_bonds` (2Y proxy, `GS2`)
+- The first term is the price-change from yield movement; the second is
+  the carry accrual
+
+### Assumptions and limitations
+- Duration is constant. In reality, duration shortens with rising yields
+  and with age; we use a midpoint estimate.
+- Convexity is ignored. Small daily yield moves (<50 bps) incur <5%
+  convexity; large moves (1980s tightening, 2022) can reach 10-20%.
+- Coupon reinvestment beyond the `yield/252` accrual is not modeled.
+- Errors compound over 50 years; the validation below sets a tolerance.
+
+### Validation methodology
+Compare synthetic daily bond returns to real total-return ETF data over
+the overlap period:
+- Long bonds: **TLT** (iShares 20+ Year Treasury Bond ETF), 2002-07+
+- Short bonds: **SHY** (iShares 1-3 Year Treasury Bond ETF), 2002-07+
+
+Resample both synthetic and ETF returns to monthly and compute:
+- Mean absolute error (MAE) of monthly returns
+- Correlation
+- Per-decade CAGR divergence (synthetic CAGR minus ETF CAGR)
+
+### Accuracy threshold
+The approximation is considered adequate if:
+- Per-decade CAGR divergence ≤ **0.50 percentage points per year** for
+  every decade in the overlap period
+- Correlation of monthly returns ≥ 0.90
+
+If either bound is violated for a given asset class, the implementation
+must splice real ETF data for the overlap period (same pattern as
+`gold`/`commodities` in "Proxy series splicing"). The approximation
+continues to apply before the ETF start date.
+
+### Invariants
+- Daily bond return is finite on every business day in 1975-01-01 → present
+- With zero yield change, daily return equals `yield[t-1] / 252` exactly
+- Circuit breaker at `|r| < 0.25` (inherited from asset-returns invariants)
+
+### Test cases
+- Unit: zero yield change for a full year yields `(1 + yield/252)^252 − 1`
+  (approximately `yield`) as the compounded annual return
+- Unit: yield moves from 5% to 6% in one day produces long-bond daily
+  return of about `-8 × 0.01 + 0.05/252 = -7.98%` (and similarly for short
+  bonds with duration 2)
+- Integration: MAE of monthly synthetic long_bonds vs TLT over the full
+  overlap period is computed and reported; the implementation record
+  shows whether the 0.50 ppt/yr / 0.90 correlation threshold is met per
+  decade
+- Integration: same validation for short_bonds vs SHY
+
+### Known open questions
+- Whether to switch to ETF data automatically once available, or continue
+  using the approximation for consistency across the full backtest.
+  Default in this spec: keep the approximation unless the threshold is
+  violated, to preserve uniform methodology across the period.
 
 ## Proxy series splicing
 

--- a/scripts/validate_bond_returns.py
+++ b/scripts/validate_bond_returns.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python3
+"""Validate synthetic bond return approximation against real ETF data.
+
+Compares synthetic daily bond returns (from ``build_asset_returns`` in
+``src.backtester``) against TLT (long bonds) and SHY (short bonds) total
+returns sourced from Yahoo Finance.
+
+See ``docs/specs/backtester.md`` section "Bond return approximation" for the
+formula and accuracy threshold being checked:
+
+    daily_return = -duration * (yield[t] - yield[t-1]) + yield[t-1] / 252
+    Per-decade CAGR divergence <= 0.50 ppt/yr
+    Correlation of monthly returns >= 0.90
+
+This is a reporting script, not a check — it always exits 0.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+ROOT = Path(__file__).resolve().parent.parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from src.backtester import build_asset_returns
+from src.data_fetcher import load_all_fred, load_all_yahoo, load_series
+
+
+CORRELATION_FLOOR = 0.90
+PER_DECADE_CAGR_TOLERANCE = 0.0050  # 0.50 percentage points per year
+
+
+def _load_etf_daily_total_returns(symbol: str) -> pd.Series:
+    """Load an ETF's daily total returns from the Yahoo cache.
+
+    Prefers the adjusted close (dividends reinvested) when available;
+    ``yfinance`` already adjusts ``Close`` for splits and dividends when the
+    ticker history is fetched without ``auto_adjust=False``.
+    """
+    df = load_series("yahoo", symbol)
+    if "Adj Close" in df.columns:
+        prices = df["Adj Close"]
+    else:
+        prices = df["Close"]
+    prices = prices.dropna().sort_index()
+    rets = prices.pct_change().dropna()
+    rets.index = pd.DatetimeIndex(rets.index)
+    rets.name = f"{symbol}_ret"
+    return rets
+
+
+def _resample_to_monthly(daily_returns: pd.Series) -> pd.Series:
+    """Compound daily returns into monthly returns."""
+    monthly = (1.0 + daily_returns).resample("ME").prod() - 1.0
+    return monthly.dropna()
+
+
+def _cagr(monthly_returns: pd.Series) -> float:
+    if len(monthly_returns) == 0:
+        return float("nan")
+    total = float((1.0 + monthly_returns).prod())
+    years = len(monthly_returns) / 12.0
+    if years <= 0 or total <= 0:
+        return float("nan")
+    return total ** (1.0 / years) - 1.0
+
+
+def _decade_label(ts: pd.Timestamp) -> str:
+    decade_start = (ts.year // 10) * 10
+    return f"{decade_start}s"
+
+
+def _per_decade_cagr(monthly: pd.Series) -> pd.Series:
+    labels = monthly.index.map(_decade_label)
+    grouped = monthly.groupby(labels)
+    return grouped.apply(_cagr)
+
+
+def _format_table(rows: list[dict]) -> str:
+    cols = ["asset", "decade", "synthetic_CAGR", "ETF_CAGR",
+            "divergence_ppt_per_yr", "correlation", "n_months"]
+    widths = {c: max(len(c), max(len(str(r[c])) for r in rows)) for c in cols}
+    header = " | ".join(c.ljust(widths[c]) for c in cols)
+    sep = "-+-".join("-" * widths[c] for c in cols)
+    lines = [header, sep]
+    for r in rows:
+        lines.append(" | ".join(str(r[c]).ljust(widths[c]) for c in cols))
+    return "\n".join(lines)
+
+
+def _validate_asset(
+    asset_name: str,
+    synthetic_daily: pd.Series,
+    etf_symbol: str,
+) -> tuple[list[dict], float, float, str]:
+    """Return (rows, mae, correlation, verdict)."""
+    etf_daily = _load_etf_daily_total_returns(etf_symbol)
+
+    synthetic_daily = synthetic_daily.dropna()
+    synthetic_daily.index = pd.DatetimeIndex(synthetic_daily.index)
+
+    synthetic_monthly = _resample_to_monthly(synthetic_daily)
+    etf_monthly = _resample_to_monthly(etf_daily)
+
+    aligned = pd.concat(
+        [synthetic_monthly.rename("synthetic"), etf_monthly.rename("etf")],
+        axis=1,
+        join="inner",
+    ).dropna()
+
+    if aligned.empty:
+        return [], float("nan"), float("nan"), "NO_OVERLAP"
+
+    mae = float((aligned["synthetic"] - aligned["etf"]).abs().mean())
+    correlation = float(aligned["synthetic"].corr(aligned["etf"]))
+
+    synth_decades = _per_decade_cagr(aligned["synthetic"])
+    etf_decades = _per_decade_cagr(aligned["etf"])
+    months_per_decade = aligned.groupby(
+        aligned.index.map(_decade_label)
+    ).size()
+
+    rows: list[dict] = []
+    max_abs_divergence = 0.0
+    for decade in synth_decades.index:
+        synth = synth_decades.loc[decade]
+        etf = etf_decades.loc[decade]
+        divergence = synth - etf
+        max_abs_divergence = max(max_abs_divergence, abs(divergence))
+        rows.append({
+            "asset": asset_name,
+            "decade": decade,
+            "synthetic_CAGR": f"{synth * 100:+.2f}%",
+            "ETF_CAGR": f"{etf * 100:+.2f}%",
+            "divergence_ppt_per_yr": f"{divergence * 100:+.2f}",
+            "correlation": f"{correlation:.3f}",
+            "n_months": int(months_per_decade.loc[decade]),
+        })
+
+    meets_cagr = max_abs_divergence <= PER_DECADE_CAGR_TOLERANCE
+    meets_corr = correlation >= CORRELATION_FLOOR
+    verdict = "PASS" if (meets_cagr and meets_corr) else "FAIL"
+    return rows, mae, correlation, verdict
+
+
+def main() -> int:
+    print("Loading cached FRED and Yahoo data...")
+    fred_data = load_all_fred()
+    yahoo_data = load_all_yahoo()
+
+    # build_asset_returns expects ``GS2_yield`` as a daily-forward-filled series.
+    if "GS2" in fred_data:
+        gs2_daily = fred_data["GS2"].squeeze().resample("B").ffill()
+        fred_data["GS2_yield"] = gs2_daily
+
+    combined = {**fred_data, **yahoo_data}
+    returns = build_asset_returns(combined, start="2002-07-01")
+
+    print(f"Synthetic returns built: {returns.index[0].date()} → "
+          f"{returns.index[-1].date()}  ({len(returns)} days)")
+
+    all_rows: list[dict] = []
+    verdicts: dict[str, tuple[float, float, str]] = {}
+
+    for asset_name, etf_symbol in [("long_bonds", "TLT"), ("short_bonds", "SHY")]:
+        synthetic_daily = returns[asset_name]
+        rows, mae, corr, verdict = _validate_asset(
+            asset_name, synthetic_daily, etf_symbol
+        )
+        all_rows.extend(rows)
+        verdicts[asset_name] = (mae, corr, verdict)
+
+    print()
+    print("Per-decade comparison (synthetic vs ETF):")
+    print(_format_table(all_rows))
+    print()
+
+    for asset_name, (mae, corr, verdict) in verdicts.items():
+        etf = "TLT" if asset_name == "long_bonds" else "SHY"
+        print(f"{asset_name} vs {etf}: "
+              f"MAE(monthly)={mae * 100:.3f}%  corr={corr:.3f}  -> {verdict} "
+              f"(threshold: per-decade |CAGR div| <= "
+              f"{PER_DECADE_CAGR_TOLERANCE * 100:.2f}ppt/yr and corr >= "
+              f"{CORRELATION_FLOOR:.2f})")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Closes #8. Validates the duration-based bond-return approximation against TLT and SHY (the only freely available total-return ETF data for long and short Treasury exposure), and lands the result as a research artifact.

**Verdict: both assets fail the spec threshold** — the splicing implementation is filed as #31.

## Spec change (`docs/specs/backtester.md`)
New "Bond return approximation" subsection promotes the formula and assumptions from a single table cell to a proper spec section:
- Formula: `daily_return = -duration × Δyield + yield/252`
- Assumptions and known limitations (constant duration, ignored convexity, simplified coupon model)
- Validation methodology: monthly comparison vs TLT (2002-07+) and SHY (2002-07+)
- Threshold: per-decade |CAGR divergence| ≤ 0.50 ppt/yr AND correlation ≥ 0.90 per asset
- Test cases (unit + integration)

## Implementation (this PR)
- `configs/series.yaml`: registered SHY (TLT was already present from earlier work)
- `scripts/validate_bond_returns.py`: deterministic comparison script — loads cached FRED yields, builds synthetic returns, loads ETF returns, prints per-decade table + PASS/FAIL line

## Validation finding (`docs/research/bond_return_validation.md`)

| asset | decade | synthetic | ETF | divergence ppt/yr | corr |
|---|---|---|---|---|---|
| long_bonds | 2000s | +4.94% | +6.02% | **−1.08** | 0.929 |
| long_bonds | 2010s | +3.81% | +7.23% | **−3.42** | 0.929 |
| long_bonds | 2020s | −0.33% | −4.07% | **+3.74** | 0.929 |
| short_bonds | 2000s | +3.52% | +3.31% | +0.21 | **0.771** |
| short_bonds | 2010s | +0.85% | +1.09% | −0.25 | **0.771** |
| short_bonds | 2020s | +2.20% | +1.83% | +0.36 | **0.771** |

- `long_bonds`: correlation passes (0.929) but per-decade divergence fails badly. Directionality (understate when rates fall, overstate when rates rise) is the **convexity-bias signature** — the duration model misses second-order effects.
- `short_bonds`: per-decade divergence within tolerance, but correlation only 0.771 — coupon roll/reinvestment effects dominate at short duration.

## What this PR does NOT do

Per #8's two-phase approach (spec → validate → decide), this PR ends at the decision. The splicing implementation (TLT/SHY for 2002+, keeping approximation pre-2002) is filed separately as **#31**.

## Reproducing
```
source .venv/bin/activate
python scripts/fetch_data.py
python scripts/validate_bond_returns.py
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)