### PR TITLE
Add changelog-check skill to track Claude Code releases (refs #33)

### DIFF
--- a/.claude/skills/changelog-check/SKILL.md
+++ b/.claude/skills/changelog-check/SKILL.md
@@ -14,7 +14,10 @@ surfaces what's new since the last time we looked.
 - User explicitly asks ("any Claude Code updates?", "check the changelog")
 - Re-evaluating a workflow issue that depends on upstream fixes — most
   notably **#33** (revisit worktree isolation)
-- Roughly every 1-2 weeks if nothing else has triggered a check
+- **Daily at session start** if `state.json`'s `last_checked` is more than
+  1 day old. Claude Code ships frequently (multiple releases most weeks);
+  a longer cadence means we'd miss fixes close to when they land. See
+  CLAUDE.md for the session-start ritual.
 
 ## Inputs
 

--- a/.claude/skills/changelog-check/SKILL.md
+++ b/.claude/skills/changelog-check/SKILL.md
@@ -1,0 +1,152 @@
+---
+name: changelog-check
+description: Use when the user asks to "check the Claude Code changelog", "see what's new in Claude Code", "look for changelog updates", "is there a fix for X yet", or wants to evaluate whether recent Claude Code releases affect this project's workflow. Also use when re-evaluating issue #33 (revisit worktree isolation once upstream is ready). Fetches the changelog, identifies entries since the last check, evaluates relevance to this project, and produces a triage report.
+---
+
+# Changelog Check
+
+Track Claude Code releases and evaluate whether any changes affect this
+project's workflow. State persists across sessions so each invocation only
+surfaces what's new since the last time we looked.
+
+## When to invoke
+
+- User explicitly asks ("any Claude Code updates?", "check the changelog")
+- Re-evaluating a workflow issue that depends on upstream fixes — most
+  notably **#33** (revisit worktree isolation)
+- Roughly every 1-2 weeks if nothing else has triggered a check
+
+## Inputs
+
+State lives in `.claude/skills/changelog-check/state.json` (committed; this
+is a solo project, so the last-checked version is a shared team fact).
+
+Schema:
+```json
+{
+  "last_version": "2.1.105",
+  "last_checked": "2026-04-14",
+  "notes": "Free-form anything-to-remember. Keep it one line."
+}
+```
+
+## Process
+
+### 1. Read state
+```
+cat .claude/skills/changelog-check/state.json
+```
+Note `last_version` and `last_checked`. If the file doesn't exist, treat
+the last version as unknown and report everything from the most recent
+~20 entries.
+
+### 2. Fetch the changelog
+```
+WebFetch https://code.claude.com/docs/en/changelog
+```
+Prompt it to extract every entry with version number newer than
+`last_version`. Prompt should specifically ask for entries mentioning the
+keywords below, PLUS any general entries after `last_version`.
+
+### 3. Evaluate relevance
+
+For each new entry, classify as one of:
+
+- **Ticks #33** — directly addresses one of issue #33's open checklist
+  items. These matter most; flag prominently and reference the specific
+  checklist item.
+- **Likely relevant** — touches an area we depend on (see keywords
+  below) but doesn't tick an open checklist item.
+- **Worth noting** — project could reasonably care at some point
+  (testing/CI, MCP, hooks, agent tool changes).
+- **Skip** — unrelated to this project's workflow (e.g., IDE extension
+  fixes, unrelated bug fixes).
+
+**Keywords that mean "pay attention":**
+- `worktree`, `isolation`, `WorktreeCreate`, `.worktreeinclude`,
+  `EnterWorktree`, `ExitWorktree`
+- `subagent`, `sub-agent`, `Agent tool`, `isolation`
+- `settings`, `permission`, `allow`, `deny`, `allowlist`
+- `hook`, `PreToolUse`, `PostToolUse`, `SessionStart`, `UserPromptSubmit`
+- `skill`, `slash command`, `/review-pr`
+- `pytest`, `GitHub Actions`, `CI`
+- `MCP`, `MCP server`, `plugin`
+
+**Keywords that usually mean "skip":**
+- VS Code / JetBrains / IDE extension stuff (we only use the CLI)
+- Windows-specific fixes (we run on macOS)
+- Bedrock / Vertex / Foundry cloud provider auth
+- Specific language or framework integrations we don't use
+
+### 4. Report
+
+Produce a summary with three sections. Keep each entry to one or two
+sentences citing the version number:
+
+```
+## Changelog check (last_version: X.Y.Z → Z.Y.Z, N new entries)
+
+### Ticks #33
+- 2.1.ZZ — <short entry> — ticks "<#33 checklist item>"
+
+### Likely relevant
+- 2.1.YY — <short entry> — why it might matter here
+
+### Worth noting
+- 2.1.XX — <short entry> — one-line "could be useful if …"
+
+(Skipped N unrelated entries covering IDE/Windows/cloud-provider fixes.)
+```
+
+Then ask the user whether to:
+- Tick the #33 item(s) (coordinator files a `gh issue comment`)
+- Pick up any of the "Likely relevant" items as concrete work
+- Just record the check and move on
+
+### 5. Update state
+
+Regardless of what the user decides, update `state.json` with the
+newest version seen and today's date. Set `notes` to a one-line summary
+of what we found (e.g., "2 #33 ticks, 1 worth noting" or "no relevant
+changes").
+
+```
+Write .claude/skills/changelog-check/state.json
+```
+
+Do NOT update state if you failed to fetch the changelog — we want to
+see the same entries next time.
+
+## Scope
+
+- Do NOT comment on or close any GitHub issues yourself. Always defer
+  to the user.
+- Do NOT update #33's checkboxes without the user saying "yes, tick
+  them" explicitly.
+- Do NOT interpret silence as confirmation. If the fetch failed or the
+  output was ambiguous, report the failure and stop.
+
+## Output example
+
+A good report looks like:
+
+> Changelog check (2.1.105 → 2.1.112, 7 new entries)
+>
+> **Ticks #33**
+> - 2.1.110 — "Fixed WorktreeCreate hook payload to include worktree_path and worktree_name for subagent-triggered worktrees" — ticks #33's *payload schema* item.
+>
+> **Likely relevant**
+> - 2.1.108 — "Added permissions.subagents section in settings.json for subagent-specific allow/deny" — may simplify our bare-Edit/Write setup if we ever re-adopt isolation.
+>
+> **Worth noting**
+> - 2.1.107 — "Added --output-format jsonl for scheduled tasks" — possibly useful for the autoresearch loop eventually.
+>
+> (Skipped 4 entries covering VS Code extension and Windows path fixes.)
+>
+> Want me to tick #33's *payload schema* checkbox?
+
+A bad report is one that:
+- Lists every entry without triage
+- Flags irrelevant entries as "relevant"
+- Claims to have found something without citing a version number
+- Updates `state.json` before the user sees the report

--- a/.claude/skills/changelog-check/state.json
+++ b/.claude/skills/changelog-check/state.json
@@ -1,5 +1,5 @@
 {
-  "last_version": "2.1.105",
+  "last_version": "2.1.108",
   "last_checked": "2026-04-14",
-  "notes": "Initial state; 2.1.98 already ticked #33 item re: subagent Edit denial inside own worktree."
+  "notes": "2.1.107/108: 0 #33 ticks; relevant: ENABLE_PROMPT_CACHING_1H, Skill-tool discovers built-in slash commands, /recap feature."
 }

--- a/.claude/skills/changelog-check/state.json
+++ b/.claude/skills/changelog-check/state.json
@@ -1,0 +1,5 @@
+{
+  "last_version": "2.1.105",
+  "last_checked": "2026-04-14",
+  "notes": "Initial state; 2.1.98 already ticked #33 item re: subagent Edit denial inside own worktree."
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,8 +120,16 @@ Examples: `explore/phase1/civilizational-indicators`, `stable/phase2/regime-clas
 **Tracking:** Bugs, features, and tasks are GitHub issues at dsdale24/big-cycle-investing.
 Labels: `exploring`, `stabilizing`, `bug`, `data`. See issue #13 for the full roadmap.
 
-Before starting work: check open issues (`gh issue list`). Reference issues in commits
-(e.g., "Fixes #1"). Commits from `stable/*` branches must reference the spec they conform to.
+**At session start (or when resuming after a gap):**
+- If `.claude/skills/changelog-check/state.json`'s `last_checked` is more than
+  ~7 days old, invoke `/skill changelog-check` to see if any Claude Code
+  updates affect this project's workflow. The skill reports new entries in
+  three buckets (ticks #33 / likely relevant / worth noting) and asks the
+  coordinator what to act on.
+- Check open issues with `gh issue list` before starting substantive work.
+
+Reference issues in commits (e.g., "Fixes #1"). Commits from `stable/*`
+branches must reference the spec they conform to.
 
 ### Maker-checker model
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,10 +122,11 @@ Labels: `exploring`, `stabilizing`, `bug`, `data`. See issue #13 for the full ro
 
 **At session start (or when resuming after a gap):**
 - If `.claude/skills/changelog-check/state.json`'s `last_checked` is more than
-  ~7 days old, invoke `/skill changelog-check` to see if any Claude Code
-  updates affect this project's workflow. The skill reports new entries in
-  three buckets (ticks #33 / likely relevant / worth noting) and asks the
-  coordinator what to act on.
+  1 day old, invoke `/skill changelog-check` to see if any Claude Code
+  updates affect this project's workflow. Claude Code ships frequently
+  (multiple releases most weeks), so a daily cadence catches fixes close to
+  when they land. The skill reports new entries in three buckets (ticks #33
+  / likely relevant / worth noting) and asks the coordinator what to act on.
 - Check open issues with `gh issue list` before starting substantive work.
 
 Reference issues in commits (e.g., "Fixes #1"). Commits from `stable/*`


### PR DESCRIPTION
## Summary

Skill to track Claude Code releases and triage whether anything in a new release affects this project's workflow. Motivated by #33 (revisit worktree isolation once upstream pain points are fixed) — we need a cheap recurring way to check whether the upstream work has progressed without requiring one of us to manually scan the full changelog.

## What lands

- **`.claude/skills/changelog-check/SKILL.md`** — the playbook. Instructions Claude follows when invoked: read state, fetch the changelog, evaluate each new entry against a list of project concerns, produce a three-section report (*ticks #33* / *likely relevant* / *worth noting*), and ask the user whether to act.
- **`.claude/skills/changelog-check/state.json`** — committed state. Seeded at `2.1.105` with a one-line note acknowledging that `2.1.98` already ticked one #33 item (subagent Edit access inside its own worktree). Future runs only surface entries newer than `last_version`.

## Why skill not hook

Hooks are shell commands — they can fetch the changelog but can't evaluate "is this relevant to us?" That evaluation needs Claude's reasoning, which is what skills are for. A future `SessionStart` hook could auto-invoke the skill if `last_checked > 7 days ago`, but that's a follow-up: prove the skill earns its keep first.

## How to invoke

- Ad-hoc: `/skill changelog-check`, or ask "check the Claude Code changelog for updates"
- Re-evaluating #33: invoke before checking whether any open checklist items are now ticked

## Scope discipline (baked into the skill)

- The skill does NOT modify GitHub issues on its own
- The skill does NOT interpret silence as confirmation
- If the fetch fails, state.json is NOT updated (so the same entries surface next time)
- The report cites version numbers for every claim; no hand-wavy "there was a change" without a pointer

## Test plan
- [ ] Invoke the skill once against the current changelog; verify no false positives
- [ ] Add an entry to `state.json.notes` summarizing that first run
- [ ] After the next real Claude Code release, invoke again; verify the newer entries appear and nothing older recurs

🤖 Generated with [Claude Code](https://claude.com/claude-code)