### PR TITLE
Opt into 1-hour prompt cache TTL (settings.json env block)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,8 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "env": {
+    "ENABLE_PROMPT_CACHING_1H": "1"
+  },
   "permissions": {
     "allow": [
       "Edit",


### PR DESCRIPTION
## Summary

Claude Code 2.1.108 added `ENABLE_PROMPT_CACHING_1H` — extends prompt-cache TTL from 5 min to 1h. Our maker-checker cycles routinely span >5 min (coordinator spec edits + multi-minute agent delegations + review runs), so the default TTL misses cache hits on CLAUDE.md and spec re-reads within a single cycle.

Set via `settings.json` `env` block (committed, project-scoped). Any collaborator running `claude` here picks it up automatically; anyone who doesn't want it overrides in `.claude/settings.local.json`.

```json
"env": {
  "ENABLE_PROMPT_CACHING_1H": "1"
}
```

Surfaced by the first real run of the `changelog-check` skill (#34).

🤖 Generated with [Claude Code](https://claude.com/claude-code)