### PR TITLE
Generalize changelog-check skill, drop hardcoded #33 references

### DIFF
--- a/.claude/skills/changelog-check/SKILL.md
+++ b/.claude/skills/changelog-check/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: changelog-check
-description: Use when the user asks to "check the Claude Code changelog", "see what's new in Claude Code", "look for changelog updates", "is there a fix for X yet", or wants to evaluate whether recent Claude Code releases affect this project's workflow. Also use when re-evaluating issue #33 (revisit worktree isolation once upstream is ready). Fetches the changelog, identifies entries since the last check, evaluates relevance to this project, and produces a triage report.
+description: Use when the user asks to "check the Claude Code changelog", "see what's new in Claude Code", "look for changelog updates", "is there a fix for X yet", or wants to evaluate whether recent Claude Code releases affect this project's workflow. Also invoke proactively at session start if `state.json`'s `last_checked` is more than a day old, or any time the user mentions a Claude Code feature that may have shipped recently. Fetches the changelog, identifies entries since the last check, evaluates relevance to this project, and produces a triage report.
 ---
 
 # Changelog Check
@@ -12,14 +12,13 @@ surfaces what's new since the last time we looked.
 ## When to invoke
 
 - User explicitly asks ("any Claude Code updates?", "check the changelog")
-- Re-evaluating a workflow issue that depends on upstream fixes — most
-  notably **#33** (revisit worktree isolation)
+- Re-evaluating a workflow issue that depends on upstream fixes
 - **Daily at session start** if `state.json`'s `last_checked` is more than
   1 day old. Claude Code ships frequently (multiple releases most weeks);
   a longer cadence means we'd miss fixes close to when they land. See
   CLAUDE.md for the session-start ritual.
 
-## Inputs
+## State
 
 State lives in `.claude/skills/changelog-check/state.json` (committed; this
 is a solo project, so the last-checked version is a shared team fact).
@@ -36,28 +35,29 @@ Schema:
 ## Process
 
 ### 1. Read state
-```
-cat .claude/skills/changelog-check/state.json
-```
-Note `last_version` and `last_checked`. If the file doesn't exist, treat
-the last version as unknown and report everything from the most recent
-~20 entries.
+
+Read `.claude/skills/changelog-check/state.json` and note `last_version`
+and `last_checked`. If the file doesn't exist, treat the last version as
+unknown and report the most recent ~30 days of entries (Claude Code
+typically ships several times per week, so a month is a reasonable
+backstop).
 
 ### 2. Fetch the changelog
-```
-WebFetch https://code.claude.com/docs/en/changelog
-```
-Prompt it to extract every entry with version number newer than
-`last_version`. Prompt should specifically ask for entries mentioning the
-keywords below, PLUS any general entries after `last_version`.
+
+Use the WebFetch tool against `https://code.claude.com/docs/en/changelog`.
+Prompt it to extract every entry with a version number newer than
+`last_version`, plus any entry mentioning the keywords below. The keyword
+hint helps WebFetch surface relevant items even if a generic extraction
+would summarize them away.
 
 ### 3. Evaluate relevance
 
 For each new entry, classify as one of:
 
-- **Ticks #33** — directly addresses one of issue #33's open checklist
-  items. These matter most; flag prominently and reference the specific
-  checklist item.
+- **Ticks an open issue** — directly addresses an open checklist item
+  on a GitHub issue in this repo (run `gh issue list` first to know
+  what's open). These matter most; flag prominently and reference the
+  specific issue and checklist item.
 - **Likely relevant** — touches an area we depend on (see keywords
   below) but doesn't tick an open checklist item.
 - **Worth noting** — project could reasonably care at some point
@@ -89,8 +89,8 @@ sentences citing the version number:
 ```
 ## Changelog check (last_version: X.Y.Z → Z.Y.Z, N new entries)
 
-### Ticks #33
-- 2.1.ZZ — <short entry> — ticks "<#33 checklist item>"
+### Ticks an open issue
+- 2.1.ZZ — <short entry> — ticks #NN's "<checklist item>"
 
 ### Likely relevant
 - 2.1.YY — <short entry> — why it might matter here
@@ -102,20 +102,22 @@ sentences citing the version number:
 ```
 
 Then ask the user whether to:
-- Tick the #33 item(s) (coordinator files a `gh issue comment`)
+- Tick the matching open-issue item(s) (coordinator files a `gh issue comment`)
 - Pick up any of the "Likely relevant" items as concrete work
 - Just record the check and move on
 
 ### 5. Update state
 
-Regardless of what the user decides, update `state.json` with the
-newest version seen and today's date. Set `notes` to a one-line summary
-of what we found (e.g., "2 #33 ticks, 1 worth noting" or "no relevant
-changes").
+**Only after the user has seen the report and responded.** Updating
+state before the user sees the report risks losing entries — if the
+user closes the session or you crash mid-response, the next invocation
+will skip them.
 
-```
-Write .claude/skills/changelog-check/state.json
-```
+When the user has acknowledged (whether by acting on the findings or
+by saying "just record it"), write `.claude/skills/changelog-check/state.json`
+with the newest version seen and today's date. Set `notes` to a one-line
+summary of what we found (e.g., "2 issue ticks, 1 worth noting" or "no
+relevant changes").
 
 Do NOT update state if you failed to fetch the changelog — we want to
 see the same entries next time.
@@ -124,8 +126,8 @@ see the same entries next time.
 
 - Do NOT comment on or close any GitHub issues yourself. Always defer
   to the user.
-- Do NOT update #33's checkboxes without the user saying "yes, tick
-  them" explicitly.
+- Do NOT update any issue's checkboxes without the user saying "yes,
+  tick them" explicitly.
 - Do NOT interpret silence as confirmation. If the fetch failed or the
   output was ambiguous, report the failure and stop.
 
@@ -135,8 +137,8 @@ A good report looks like:
 
 > Changelog check (2.1.105 → 2.1.112, 7 new entries)
 >
-> **Ticks #33**
-> - 2.1.110 — "Fixed WorktreeCreate hook payload to include worktree_path and worktree_name for subagent-triggered worktrees" — ticks #33's *payload schema* item.
+> **Ticks an open issue**
+> - 2.1.110 — "Fixed WorktreeCreate hook payload to include worktree_path and worktree_name for subagent-triggered worktrees" — ticks #NN's *payload schema* item.
 >
 > **Likely relevant**
 > - 2.1.108 — "Added permissions.subagents section in settings.json for subagent-specific allow/deny" — may simplify our bare-Edit/Write setup if we ever re-adopt isolation.
@@ -146,7 +148,7 @@ A good report looks like:
 >
 > (Skipped 4 entries covering VS Code extension and Windows path fixes.)
 >
-> Want me to tick #33's *payload schema* checkbox?
+> Want me to tick #NN's *payload schema* checkbox?
 
 A bad report is one that:
 - Lists every entry without triage


### PR DESCRIPTION
## Summary
- Strips hardcoded references to issue #33 throughout the changelog-check skill so it reads as a general "check Claude Code releases against this project's open issues" workflow
- Applies a cleanup pass from the skill-creator review:
  - More proactive triggering description (session-start, feature mentions)
  - Hoists the "don't update state before user sees report" constraint into Step 5 with reasoning
  - Reframes WebFetch invocation as prose (was reading like a literal shell command)
  - Renames "Inputs" → "State"
  - Grounds the unknown-state fallback at "~30 days of entries" with reasoning
  - Picks the full-path form for state.json everywhere

## Test plan
- [ ] Visually inspect the diff to confirm no behavior change beyond the description and structure
- [ ] Run \`/skill changelog-check\` on a fresh session to confirm the skill still triggers and the body still makes sense to a fresh agent