### PR TITLE
Splice TLT/SHY into bond returns 2002+ (#31)

### DIFF
--- a/docs/specs/backtester.md
+++ b/docs/specs/backtester.md
@@ -1,7 +1,7 @@
 # Backtester Specification
 
 Status: **Stabilizing**
-Last updated: 2026-04-13 (bond return approximation validated — see issue #8)
+Last updated: 2026-04-14 (bond ETF splicing required by validation — see issues #8, #31)
 
 ## Purpose
 
@@ -45,8 +45,8 @@ Specifically:
 | Asset class | Primary source | Pre-data proxy | Notes |
 |-------------|---------------|----------------|-------|
 | equities | ^GSPC daily close | — | Available from 1975 |
-| long_bonds | Derived from 10Y yield (^TNX) | — | Return ≈ -duration × Δyield + yield/252 |
-| short_bonds | Derived from 2Y yield (GS2) | — | Return ≈ -2 × Δyield + yield/252 |
+| long_bonds | TLT adjusted close (2002-07-30+) | Derived from 10Y yield (^TNX), 1975 → 2002-07-29 | Spliced — see "ETF splicing" below |
+| short_bonds | SHY adjusted close (2002-07-30+) | Derived from 2Y yield (GS2), 1975 → 2002-07-29 | Spliced — see "ETF splicing" below |
 | gold | GC=F daily close (2000+) | WPUSI019011 monthly (1975-2000) | PPI: Metals & Metal Products; imperfect proxy, tracks directionally |
 | commodities | CL=F daily close (2000+) | DCOILWTICO daily (1986-2000), PPIACO monthly (1975-1986) | Two-stage proxy: WTI spot where available, PPI All Commodities before |
 | cash | FEDFUNDS / 252 | — | Monthly rate, forward-filled to daily |
@@ -138,11 +138,73 @@ continues to apply before the ETF start date.
   decade
 - Integration: same validation for short_bonds vs SHY
 
+### ETF splicing (mandatory for validated assets)
+
+The validation in #8 (`docs/research/bond_return_validation.md`) found that
+both `long_bonds` and `short_bonds` exceed the accuracy threshold over the
+2002+ overlap period — `long_bonds` violates the per-decade CAGR bound
+(up to 3.4 ppt/yr divergence in the 2010s, the convexity signature) and
+`short_bonds` violates the correlation bound (0.77 vs 0.90 floor). Per
+the rule above, both must splice ETF data for the overlap period.
+
+#### Splice points
+
+| Asset class | Date range | Source | Frequency |
+|---|---|---|---|
+| long_bonds | 1975-01-02 → 2002-07-29 | ^TNX duration approximation | daily (derived) |
+| long_bonds | 2002-07-30 → present | TLT (Yahoo) | daily |
+| short_bonds | 1975-01-02 → 2002-07-29 | GS2 duration approximation | daily (derived) |
+| short_bonds | 2002-07-30 → present | SHY (Yahoo) | daily |
+
+The splice date is the first trading day on which the ETF has data and
+belongs exclusively to the newer source (same exclusivity rule as
+"Proxy series splicing"). Splice dates are not hardcoded — they are
+derived dynamically as the first trading day of the ETF's history.
+
+#### Total-return sourcing
+
+ETF returns are computed from `pct_change()` of `Adj Close`, which
+incorporates dividend reinvestment. Bond ETFs distribute monthly coupon
+income, and using `Close` would discard a material fraction of total
+return — that is the whole reason the duration approximation includes a
+`yield / 252` carry term in the first place. The post-splice series must
+preserve the same total-return semantics as the pre-splice series.
+
+#### Invariants (bond splicing)
+
+- No gap, no overlap at the splice date — every business day belongs to
+  exactly one source
+- Source labels are populated on every business day the returns frame is
+  populated on (consistent with "Proxy series splicing → Invariants")
+- Pre-splice returns must equal the pure-approximation regime exactly —
+  splicing only replaces post-2002 returns
+- The post-splice series satisfies the accuracy threshold trivially
+  because it IS the ETF data over the overlap period
+
+#### Test cases (splicing)
+
+- The trading day immediately before the splice date is sourced from the
+  duration approximation; the splice date itself is sourced from TLT
+  (long_bonds) or SHY (short_bonds)
+- Pre-2002 spliced returns for both bond assets equal the duration
+  approximation produced by the same yield series (regression check
+  against the unspliced path)
+- For any month fully within the post-splice window, the spliced
+  monthly return equals the ETF monthly return (modulo float tolerance)
+- Source label transitions exactly once per asset, on the splice date,
+  with no NaN labels on populated business days
+
 ### Known open questions
-- Whether to switch to ETF data automatically once available, or continue
-  using the approximation for consistency across the full backtest.
-  Default in this spec: keep the approximation unless the threshold is
-  violated, to preserve uniform methodology across the period.
+
+- **Pre-2002 uncertainty communication.** The 1975 → 2002-07-29 window
+  uses the duration approximation and has no ETF benchmark to bound its
+  error. The convexity-bias pattern observed post-2002 is likely also
+  present pre-2002 (rates fell sharply over 1981-1999). Surfacing this
+  in `BacktestResult` metadata so analysis can flag pre-2002 bond
+  exposure as approximation-only is open. Tracked separately.
+- **1990s hybrid.** ICE BofA Treasury indices on FRED extend the
+  validation window earlier than TLT/SHY; could tighten the pre-2002
+  estimate without requiring a third splice. Out of scope for #31.
 
 ## Proxy series splicing
 

--- a/src/backtester.py
+++ b/src/backtester.py
@@ -24,6 +24,12 @@ GOLD_DEFAULT_SPLICE = pd.Timestamp("2000-08-30")
 COMMODITIES_MONTHLY_TO_DAILY_SPLICE = pd.Timestamp("1986-01-02")
 COMMODITIES_DAILY_TO_FUTURES_SPLICE = pd.Timestamp("2000-08-23")
 
+# Bond ETF splicing (see docs/specs/backtester.md "ETF splicing", issue #31).
+# The splice date is NOT hardcoded — it is derived dynamically as the first
+# trading day of the ETF's history. TLT/SHY both began trading 2002-07-30.
+LONG_BONDS_ETF = "TLT"
+SHORT_BONDS_ETF = "SHY"
+
 
 # ---------------------------------------------------------------------------
 # Transaction cost schedule (see docs/specs/backtester.md, issue #6)
@@ -232,6 +238,101 @@ def _build_commodities_returns(
     return splice_returns(segments)
 
 
+def _long_bonds_approximation(data: dict[str, pd.DataFrame]) -> pd.Series:
+    """Duration-based daily return approximation from the 10Y yield (^TNX).
+
+    Preserved bitwise-identical to the pre-splicing logic: duration=8,
+    carry=yield[t-1]/252, clipped to +/-10% per day. See
+    docs/specs/backtester.md "Bond return approximation → Formula".
+    """
+    tnx = data.get("^TNX")
+    if tnx is None:
+        return pd.Series(dtype=float, index=pd.DatetimeIndex([]))
+    y = tnx["Close"] / 100
+    duration = 8.0
+    bond_ret = -duration * y.diff() + y.shift(1) / 252
+    return bond_ret.clip(-0.10, 0.10)
+
+
+def _short_bonds_approximation(data: dict[str, pd.DataFrame]) -> pd.Series:
+    """Duration-based daily return approximation from the 2Y yield (GS2).
+
+    Preserved bitwise-identical to the pre-splicing logic: duration=2,
+    carry=yield[t-1]/252, clipped to +/-5% per day. See
+    docs/specs/backtester.md "Bond return approximation → Formula".
+    """
+    gs2 = data.get("GS2_yield")
+    if gs2 is None:
+        return pd.Series(dtype=float, index=pd.DatetimeIndex([]))
+    y2 = gs2 / 100
+    short_bond_ret = -2.0 * y2.diff() + y2.shift(1) / 252
+    return short_bond_ret.clip(-0.05, 0.05)
+
+
+def _etf_total_returns(df: pd.DataFrame) -> pd.Series:
+    """Compute daily ETF total returns from Adj Close (fallback to Close).
+
+    ``Adj Close`` incorporates dividend reinvestment, which is essential for
+    bond ETFs whose coupons are distributed monthly. See
+    docs/specs/backtester.md "ETF splicing → Total-return sourcing".
+    """
+    if "Adj Close" in df.columns:
+        prices = df["Adj Close"]
+    else:
+        prices = df["Close"]
+    return prices.pct_change()
+
+
+def _build_long_bonds_returns(
+    data: dict[str, pd.DataFrame],
+    trading_index: pd.DatetimeIndex,
+) -> tuple[pd.Series, pd.Series]:
+    """Build spliced long_bonds returns: ^TNX approximation -> TLT.
+
+    See docs/specs/backtester.md "ETF splicing (mandatory for validated assets)".
+    """
+    segments: list[tuple[pd.Series, str]] = []
+
+    approx = _long_bonds_approximation(data)
+    if not approx.empty:
+        segments.append((approx, "^TNX"))
+
+    tlt = data.get(LONG_BONDS_ETF)
+    if tlt is not None:
+        segments.append((_etf_total_returns(tlt), LONG_BONDS_ETF))
+
+    if not segments:
+        empty = pd.Series(dtype=float, index=trading_index)
+        return empty, pd.Series(pd.NA, index=trading_index, dtype=object)
+
+    return splice_returns(segments)
+
+
+def _build_short_bonds_returns(
+    data: dict[str, pd.DataFrame],
+    trading_index: pd.DatetimeIndex,
+) -> tuple[pd.Series, pd.Series]:
+    """Build spliced short_bonds returns: GS2 approximation -> SHY.
+
+    See docs/specs/backtester.md "ETF splicing (mandatory for validated assets)".
+    """
+    segments: list[tuple[pd.Series, str]] = []
+
+    approx = _short_bonds_approximation(data)
+    if not approx.empty:
+        segments.append((approx, "GS2_yield"))
+
+    shy = data.get(SHORT_BONDS_ETF)
+    if shy is not None:
+        segments.append((_etf_total_returns(shy), SHORT_BONDS_ETF))
+
+    if not segments:
+        empty = pd.Series(dtype=float, index=trading_index)
+        return empty, pd.Series(pd.NA, index=trading_index, dtype=object)
+
+    return splice_returns(segments)
+
+
 def build_asset_returns(
     data: dict[str, pd.DataFrame],
     start: str = "1975-01-01",
@@ -273,22 +374,8 @@ def build_asset_returns(
         eq_ret = empty_datetime_series.copy()
         trading_index = pd.DatetimeIndex([])
 
-    tnx = data.get("^TNX")
-    if tnx is not None:
-        y = tnx["Close"] / 100
-        duration = 8.0
-        bond_ret = -duration * y.diff() + y.shift(1) / 252
-        bond_ret = bond_ret.clip(-0.10, 0.10)
-    else:
-        bond_ret = empty_datetime_series.copy()
-
-    gs2 = data.get("GS2_yield")
-    if gs2 is not None:
-        y2 = gs2 / 100
-        short_bond_ret = -2.0 * y2.diff() + y2.shift(1) / 252
-        short_bond_ret = short_bond_ret.clip(-0.05, 0.05)
-    else:
-        short_bond_ret = empty_datetime_series.copy()
+    long_bond_ret, long_bond_src = _build_long_bonds_returns(data, trading_index)
+    short_bond_ret, short_bond_src = _build_short_bonds_returns(data, trading_index)
 
     gold_ret, gold_src = _build_gold_returns(data, trading_index)
     comm_ret, comm_src = _build_commodities_returns(data, trading_index)
@@ -301,7 +388,7 @@ def build_asset_returns(
 
     returns = pd.DataFrame({
         "equities": eq_ret,
-        "long_bonds": bond_ret,
+        "long_bonds": long_bond_ret,
         "short_bonds": short_bond_ret,
         "gold": gold_ret,
         "commodities": comm_ret,
@@ -325,8 +412,8 @@ def build_asset_returns(
 
     sources = pd.DataFrame({
         "equities": "^GSPC",
-        "long_bonds": "^TNX",
-        "short_bonds": "GS2_yield",
+        "long_bonds": long_bond_src,
+        "short_bonds": short_bond_src,
         "gold": gold_src,
         "commodities": comm_src,
         "cash": "FEDFUNDS",

--- a/tests/test_bond_splicing.py
+++ b/tests/test_bond_splicing.py
@@ -258,30 +258,120 @@ def test_short_bonds_post_splice_monthly_matches_shy(synthetic_data):
 @pytest.mark.spec
 def test_long_bonds_uses_adj_close_not_close(synthetic_data):
     """docs/specs/backtester.md "ETF splicing → Total-return sourcing":
-    ETF returns are computed from ``Adj Close``, not ``Close`` — dividends
-    must be reinvested."""
+    "ETF returns are computed from ``pct_change()`` of ``Adj Close``, which
+    incorporates dividend reinvestment. Bond ETFs distribute monthly coupon
+    income, and using ``Close`` would discard a material fraction of total
+    return."
+
+    Discriminating fixture: on a chosen post-splice day we simulate a
+    dividend ex-day by dropping ``Close`` by 1.5% while leaving ``Adj Close``
+    continuous. ``Adj Close.pct_change()`` and ``Close.pct_change()`` then
+    differ on that day, so the test would fail if the implementation read
+    ``Close`` instead of ``Adj Close``.
+    """
+    tlt = synthetic_data[LONG_BONDS_ETF].copy()
+    ex_day = pd.Timestamp("2003-03-17")  # mid-month, well past splice boundary
+    assert ex_day in tlt.index, "fixture must contain the ex-day"
+    # Dividend ex-day: Close drops 1.5% on this single day; Adj Close stays
+    # continuous (back-adjusted upstream). The Close column becomes the
+    # original Close (= Adj Close * 0.9) scaled down by 0.985 from ex_day on.
+    drop = 0.015
+    mask = tlt.index >= ex_day
+    tlt.loc[mask, "Close"] = tlt.loc[mask, "Close"] * (1.0 - drop)
+    synthetic_data = {**synthetic_data, LONG_BONDS_ETF: tlt}
+
+    adj_ret = tlt["Adj Close"].pct_change().loc[ex_day]
+    close_ret = tlt["Close"].pct_change().loc[ex_day]
+    # Sanity: the fixture genuinely discriminates between the two sources.
+    assert not np.isclose(adj_ret, close_ret, atol=1e-6), (
+        "Fixture failed to make Adj Close and Close pct_change differ on the "
+        "ex-day; test would not be a real discriminator."
+    )
+
     returns = build_asset_returns(synthetic_data, start="1975-01-01")
 
-    tlt = synthetic_data[LONG_BONDS_ETF]
-    # Fixture deliberately sets Close = Adj Close * 0.9, so pct_change
-    # values coincide except on the boundary day (first day after splice),
-    # where the 10% level jump between Close and Adj Close would reveal which
-    # column we used. The spliced boundary day's return must match Adj Close
-    # pct_change -- not Close pct_change.
-    boundary_day = tlt.index[1]  # 2002-07-31 (second trading day of TLT)
-    adj_ret = tlt["Adj Close"].pct_change().loc[boundary_day]
-    close_ret = tlt["Close"].pct_change().loc[boundary_day]
-    # For this fixture adj_ret == close_ret (multiplicative scale factor),
-    # so sameness does not discriminate. Instead check that swapping the
-    # input data (removing Adj Close) changes the result — we verify by
-    # reading the code path directly through Adj Close comparison.
-    assert returns.loc[boundary_day, "long_bonds"] == pytest.approx(
-        adj_ret, abs=1e-12
+    spliced = returns.loc[ex_day, "long_bonds"]
+    assert spliced == pytest.approx(adj_ret, abs=1e-12), (
+        "long_bonds spliced return on dividend ex-day must equal "
+        "Adj Close.pct_change() (got Close.pct_change()?)"
     )
-    # close_ret is computed only to prove the fixture structure; the monthly
-    # post-splice match test already pins Adj Close as the source.
-    assert close_ret == pytest.approx(adj_ret, abs=1e-12), (
-        "Fixture invariant: Close is a constant scale of Adj Close"
+    assert not np.isclose(spliced, close_ret, atol=1e-6), (
+        "long_bonds spliced return must not equal Close.pct_change() on the "
+        "dividend ex-day"
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.spec
+def test_short_bonds_uses_adj_close_not_close(synthetic_data):
+    """docs/specs/backtester.md "ETF splicing → Total-return sourcing":
+    same Adj-Close-required invariant as long_bonds, applied to SHY.
+
+    Discriminating fixture: simulate a SHY dividend ex-day by dropping
+    ``Close`` while leaving ``Adj Close`` continuous, then assert the
+    spliced ``short_bonds`` return on that day matches Adj Close, not Close.
+    """
+    shy = synthetic_data[SHORT_BONDS_ETF].copy()
+    ex_day = pd.Timestamp("2005-06-15")
+    assert ex_day in shy.index, "fixture must contain the ex-day"
+    drop = 0.015
+    mask = shy.index >= ex_day
+    shy.loc[mask, "Close"] = shy.loc[mask, "Close"] * (1.0 - drop)
+    synthetic_data = {**synthetic_data, SHORT_BONDS_ETF: shy}
+
+    adj_ret = shy["Adj Close"].pct_change().loc[ex_day]
+    close_ret = shy["Close"].pct_change().loc[ex_day]
+    assert not np.isclose(adj_ret, close_ret, atol=1e-6), (
+        "Fixture failed to make Adj Close and Close pct_change differ on the "
+        "ex-day; test would not be a real discriminator."
+    )
+
+    returns = build_asset_returns(synthetic_data, start="1975-01-01")
+
+    spliced = returns.loc[ex_day, "short_bonds"]
+    assert spliced == pytest.approx(adj_ret, abs=1e-12), (
+        "short_bonds spliced return on dividend ex-day must equal "
+        "Adj Close.pct_change() (got Close.pct_change()?)"
+    )
+    assert not np.isclose(spliced, close_ret, atol=1e-6), (
+        "short_bonds spliced return must not equal Close.pct_change() on the "
+        "dividend ex-day"
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.spec
+def test_long_bonds_falls_back_to_close_when_adj_close_missing(synthetic_data):
+    """docs/specs/backtester.md "ETF splicing → Total-return sourcing":
+    ``_etf_total_returns`` reads ``Adj Close`` when present and falls back to
+    ``Close`` otherwise. This test exercises the fallback branch by handing
+    in a TLT fixture with only a ``Close`` column and verifies the post-
+    splice ``long_bonds`` returns match ``Close.pct_change()`` cleanly.
+    """
+    tlt = synthetic_data[LONG_BONDS_ETF].copy()
+    # Drop Adj Close — leave only Close. The implementation should fall back.
+    tlt = tlt.drop(columns=["Adj Close"])
+    assert "Adj Close" not in tlt.columns
+    assert "Close" in tlt.columns
+    synthetic_data = {**synthetic_data, LONG_BONDS_ETF: tlt}
+
+    returns = build_asset_returns(synthetic_data, start="1975-01-01")
+
+    expected = tlt["Close"].pct_change()
+    # Pick a month fully inside the post-splice window (same shape as the
+    # post-splice monthly match test) and compare daily returns directly.
+    month_start = pd.Timestamp("2003-03-01")
+    mask_spliced = (
+        (returns.index.year == month_start.year)
+        & (returns.index.month == month_start.month)
+    )
+    got = returns.loc[mask_spliced, "long_bonds"]
+    exp = expected.reindex(got.index)
+    aligned = pd.DataFrame({"got": got, "expected": exp}).dropna(
+        subset=["expected"]
+    )
+    np.testing.assert_allclose(
+        aligned["got"].values, aligned["expected"].values, atol=1e-12, rtol=0
     )
 
 

--- a/tests/test_bond_splicing.py
+++ b/tests/test_bond_splicing.py
@@ -1,0 +1,331 @@
+"""Tests for bond ETF splicing in ``build_asset_returns``.
+
+Covers the test cases listed in ``docs/specs/backtester.md`` under
+"Bond return approximation → ETF splicing (mandatory for validated assets)
+→ Test cases (splicing)". Tests use small synthetic DataFrames so they do
+not require a FRED API key or network access.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from src.backtester import (
+    LONG_BONDS_ETF,
+    SHORT_BONDS_ETF,
+    build_asset_returns,
+)
+
+
+# ---------------------------------------------------------------------------
+# Synthetic fixture construction
+# ---------------------------------------------------------------------------
+
+TLT_SPLICE = pd.Timestamp("2002-07-30")  # first trading day for TLT/SHY
+SHY_SPLICE = pd.Timestamp("2002-07-30")
+
+
+def _business_days(start: str, end: str) -> pd.DatetimeIndex:
+    return pd.bdate_range(start=start, end=end)
+
+
+def _make_price_df(
+    index: pd.DatetimeIndex,
+    start_price: float = 100.0,
+    drift: float = 0.0002,
+    seed: int = 0,
+    include_close: bool = True,
+) -> pd.DataFrame:
+    """Build a synthetic ETF DataFrame with an ``Adj Close`` column.
+
+    ``Adj Close`` differs slightly from ``Close`` to simulate dividend
+    reinvestment — tests that rely on Adj Close use this to verify the code
+    path actually reads ``Adj Close``, not ``Close``.
+    """
+    rng = np.random.default_rng(seed)
+    rets = rng.normal(drift, 0.005, size=len(index))
+    adj = start_price * np.cumprod(1.0 + rets)
+    data = {"Adj Close": adj}
+    if include_close:
+        # Deliberately diverge so Close != Adj Close: a 10% level gap.
+        data["Close"] = adj * 0.9
+    return pd.DataFrame(data, index=index)
+
+
+def _make_yield_df(
+    index: pd.DatetimeIndex,
+    start_yield_pct: float = 7.5,
+    drift: float = 0.0,
+    vol: float = 0.02,
+    seed: int = 0,
+) -> pd.DataFrame:
+    """Build a synthetic yield series (^TNX / GS2-shaped) in percent units.
+
+    ``^TNX`` is loaded as a DataFrame with a ``Close`` column holding yield
+    values in percent (e.g., 7.5 means 7.5%).
+    """
+    rng = np.random.default_rng(seed)
+    rets = rng.normal(drift, vol, size=len(index))
+    levels = start_yield_pct * np.cumprod(1.0 + rets)
+    levels = np.clip(levels, 0.5, 20.0)
+    return pd.DataFrame({"Close": levels}, index=index)
+
+
+@pytest.fixture
+def trading_index() -> pd.DatetimeIndex:
+    return _business_days("1975-01-01", "2010-12-31")
+
+
+@pytest.fixture
+def synthetic_data(trading_index: pd.DatetimeIndex) -> dict:
+    """Minimal synthetic ``data`` dict for bond splicing tests."""
+    tnx = _make_yield_df(trading_index, start_yield_pct=7.5, vol=0.015, seed=101)
+    gs2_daily = _make_yield_df(
+        trading_index, start_yield_pct=6.0, vol=0.02, seed=102
+    )
+    gs2_series = gs2_daily["Close"].rename("GS2_yield")
+
+    etf_idx = _business_days("2002-07-30", "2010-12-31")
+    tlt = _make_price_df(etf_idx, start_price=90.0, drift=0.0001, seed=201)
+    shy = _make_price_df(etf_idx, start_price=80.0, drift=0.00005, seed=202)
+
+    sp = _make_price_df(
+        trading_index, start_price=70.0, drift=0.0003, seed=15, include_close=False
+    )
+    # build_asset_returns reads S&P via ``Close`` — give it one.
+    sp["Close"] = sp["Adj Close"]
+
+    fed = pd.Series(
+        5.0,
+        index=pd.date_range("1975-01-01", "2010-12-01", freq="MS"),
+        name="FEDFUNDS",
+    )
+
+    return {
+        "^GSPC": sp,
+        "^TNX": tnx,
+        "GS2_yield": gs2_series,
+        "FEDFUNDS": fed,
+        LONG_BONDS_ETF: tlt,
+        SHORT_BONDS_ETF: shy,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Splice boundary: day-before = approximation, splice-day = ETF
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+@pytest.mark.spec
+def test_long_bonds_splice_boundary(synthetic_data):
+    """docs/specs/backtester.md "ETF splicing → Test cases (splicing)":
+    the trading day immediately before the splice date is sourced from the
+    duration approximation; the splice date itself is sourced from TLT."""
+    _, sources = build_asset_returns(
+        synthetic_data, start="1975-01-01", return_sources=True
+    )
+    prev = sources.index[sources.index < TLT_SPLICE][-1]
+    assert sources.loc[prev, "long_bonds"] == "^TNX"
+    assert sources.loc[TLT_SPLICE, "long_bonds"] == LONG_BONDS_ETF
+    assert sources.loc[prev, "long_bonds"] != sources.loc[TLT_SPLICE, "long_bonds"]
+
+
+@pytest.mark.unit
+@pytest.mark.spec
+def test_short_bonds_splice_boundary(synthetic_data):
+    """docs/specs/backtester.md "ETF splicing → Test cases (splicing)":
+    day before splice belongs to GS2 approximation; splice day belongs to SHY."""
+    _, sources = build_asset_returns(
+        synthetic_data, start="1975-01-01", return_sources=True
+    )
+    prev = sources.index[sources.index < SHY_SPLICE][-1]
+    assert sources.loc[prev, "short_bonds"] == "GS2_yield"
+    assert sources.loc[SHY_SPLICE, "short_bonds"] == SHORT_BONDS_ETF
+    assert sources.loc[prev, "short_bonds"] != sources.loc[SHY_SPLICE, "short_bonds"]
+
+
+# ---------------------------------------------------------------------------
+# Pre-2002 spliced returns equal the pure-approximation path (regression)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+@pytest.mark.spec
+def test_long_bonds_pre_splice_matches_approximation(synthetic_data):
+    """docs/specs/backtester.md "ETF splicing → Invariants":
+    Pre-splice returns must equal the pure-approximation regime exactly."""
+    returns = build_asset_returns(synthetic_data, start="1975-01-01")
+
+    tnx = synthetic_data["^TNX"]
+    y = tnx["Close"] / 100
+    expected = (-8.0 * y.diff() + y.shift(1) / 252).clip(-0.10, 0.10)
+
+    pre = returns.loc[returns.index < TLT_SPLICE, "long_bonds"]
+    expected_pre = expected.reindex(pre.index)
+    # Pre-splice window: returns come from the approximation, except the first
+    # business day where .diff() is NaN → zero-filled by build_asset_returns.
+    aligned = pd.DataFrame({"got": pre, "expected": expected_pre})
+    nonnan = aligned.dropna(subset=["expected"])
+    np.testing.assert_allclose(
+        nonnan["got"].values, nonnan["expected"].values, atol=0, rtol=0
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.spec
+def test_short_bonds_pre_splice_matches_approximation(synthetic_data):
+    """docs/specs/backtester.md "ETF splicing → Invariants":
+    Pre-splice short_bonds returns equal the pure duration approximation."""
+    returns = build_asset_returns(synthetic_data, start="1975-01-01")
+
+    y2 = synthetic_data["GS2_yield"] / 100
+    expected = (-2.0 * y2.diff() + y2.shift(1) / 252).clip(-0.05, 0.05)
+
+    pre = returns.loc[returns.index < SHY_SPLICE, "short_bonds"]
+    expected_pre = expected.reindex(pre.index)
+    aligned = pd.DataFrame({"got": pre, "expected": expected_pre})
+    nonnan = aligned.dropna(subset=["expected"])
+    np.testing.assert_allclose(
+        nonnan["got"].values, nonnan["expected"].values, atol=0, rtol=0
+    )
+
+
+# ---------------------------------------------------------------------------
+# Post-splice monthly returns equal the ETF's monthly returns
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+@pytest.mark.spec
+def test_long_bonds_post_splice_monthly_matches_tlt(synthetic_data):
+    """docs/specs/backtester.md "ETF splicing → Test cases (splicing)":
+    for a month fully inside the post-splice window, spliced monthly return
+    equals the ETF monthly return within tolerance."""
+    returns = build_asset_returns(synthetic_data, start="1975-01-01")
+
+    tlt = synthetic_data[LONG_BONDS_ETF]
+    etf_daily = tlt["Adj Close"].pct_change()
+
+    # Pick a month fully inside post-splice window (2003-03 is entirely past
+    # TLT's 2002-07-30 inception, with no boundary effects).
+    month_start = pd.Timestamp("2003-03-01")
+    mask_spliced = (
+        (returns.index.year == month_start.year)
+        & (returns.index.month == month_start.month)
+    )
+    mask_etf = (
+        (etf_daily.index.year == month_start.year)
+        & (etf_daily.index.month == month_start.month)
+    )
+
+    spliced_monthly = (1.0 + returns.loc[mask_spliced, "long_bonds"]).prod() - 1.0
+    etf_monthly = (1.0 + etf_daily[mask_etf].dropna()).prod() - 1.0
+
+    assert spliced_monthly == pytest.approx(etf_monthly, abs=1e-10)
+
+
+@pytest.mark.unit
+@pytest.mark.spec
+def test_short_bonds_post_splice_monthly_matches_shy(synthetic_data):
+    """docs/specs/backtester.md "ETF splicing → Test cases (splicing)":
+    post-splice monthly return equals SHY's monthly return."""
+    returns = build_asset_returns(synthetic_data, start="1975-01-01")
+
+    shy = synthetic_data[SHORT_BONDS_ETF]
+    etf_daily = shy["Adj Close"].pct_change()
+
+    month_start = pd.Timestamp("2005-06-01")
+    mask_spliced = (
+        (returns.index.year == month_start.year)
+        & (returns.index.month == month_start.month)
+    )
+    mask_etf = (
+        (etf_daily.index.year == month_start.year)
+        & (etf_daily.index.month == month_start.month)
+    )
+
+    spliced_monthly = (1.0 + returns.loc[mask_spliced, "short_bonds"]).prod() - 1.0
+    etf_monthly = (1.0 + etf_daily[mask_etf].dropna()).prod() - 1.0
+
+    assert spliced_monthly == pytest.approx(etf_monthly, abs=1e-10)
+
+
+# ---------------------------------------------------------------------------
+# Adj Close (not Close) is the total-return source
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+@pytest.mark.spec
+def test_long_bonds_uses_adj_close_not_close(synthetic_data):
+    """docs/specs/backtester.md "ETF splicing → Total-return sourcing":
+    ETF returns are computed from ``Adj Close``, not ``Close`` — dividends
+    must be reinvested."""
+    returns = build_asset_returns(synthetic_data, start="1975-01-01")
+
+    tlt = synthetic_data[LONG_BONDS_ETF]
+    # Fixture deliberately sets Close = Adj Close * 0.9, so pct_change
+    # values coincide except on the boundary day (first day after splice),
+    # where the 10% level jump between Close and Adj Close would reveal which
+    # column we used. The spliced boundary day's return must match Adj Close
+    # pct_change -- not Close pct_change.
+    boundary_day = tlt.index[1]  # 2002-07-31 (second trading day of TLT)
+    adj_ret = tlt["Adj Close"].pct_change().loc[boundary_day]
+    close_ret = tlt["Close"].pct_change().loc[boundary_day]
+    # For this fixture adj_ret == close_ret (multiplicative scale factor),
+    # so sameness does not discriminate. Instead check that swapping the
+    # input data (removing Adj Close) changes the result — we verify by
+    # reading the code path directly through Adj Close comparison.
+    assert returns.loc[boundary_day, "long_bonds"] == pytest.approx(
+        adj_ret, abs=1e-12
+    )
+    # close_ret is computed only to prove the fixture structure; the monthly
+    # post-splice match test already pins Adj Close as the source.
+    assert close_ret == pytest.approx(adj_ret, abs=1e-12), (
+        "Fixture invariant: Close is a constant scale of Adj Close"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Source label transitions exactly once per asset, no NaN on populated days
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+@pytest.mark.spec
+def test_long_bonds_source_transitions_exactly_once(synthetic_data):
+    """docs/specs/backtester.md "ETF splicing → Test cases (splicing)":
+    source label transitions exactly once, on the splice date, with no NaN
+    labels on populated business days."""
+    _, sources = build_asset_returns(
+        synthetic_data, start="1975-01-01", return_sources=True
+    )
+    src = sources["long_bonds"]
+    # No NaN labels anywhere in the populated range.
+    assert src.notna().all(), "long_bonds source has NaN labels"
+    # Exactly one transition between consecutive values.
+    transitions = (src != src.shift(1)).sum()
+    # First row is always a transition by definition of the shift; subtract it.
+    assert transitions - 1 == 1, (
+        f"expected exactly one splice transition, saw {transitions - 1}"
+    )
+    # The transition lands on the splice date.
+    change_mask = src != src.shift(1)
+    change_dates = src.index[change_mask]
+    # First change date is the first populated row; second is the splice.
+    assert change_dates[-1] == TLT_SPLICE
+
+
+@pytest.mark.unit
+@pytest.mark.spec
+def test_short_bonds_source_transitions_exactly_once(synthetic_data):
+    """docs/specs/backtester.md "ETF splicing → Test cases (splicing)":
+    short_bonds source transitions exactly once, on the SHY splice date."""
+    _, sources = build_asset_returns(
+        synthetic_data, start="1975-01-01", return_sources=True
+    )
+    src = sources["short_bonds"]
+    assert src.notna().all(), "short_bonds source has NaN labels"
+    transitions = (src != src.shift(1)).sum()
+    assert transitions - 1 == 1
+    change_mask = src != src.shift(1)
+    change_dates = src.index[change_mask]
+    assert change_dates[-1] == SHY_SPLICE


### PR DESCRIPTION
## Summary
Per #8's validation, the duration approximation exceeds the spec accuracy threshold for both \`long_bonds\` (CAGR divergence up to 3.4 ppt/yr — convexity bias) and \`short_bonds\` (correlation 0.77 vs 0.90 floor) over the 2002+ overlap. The spec already mandated splicing on threshold violation; this PR implements it.

## Changes

**Spec** (\`docs/specs/backtester.md\`)
- "Asset returns → Asset class definitions" updated to show TLT/SHY post-2002 + duration approximation pre-2002 for both bond assets
- New "Bond return approximation → ETF splicing (mandatory for validated assets)" subsection: splice points, total-return sourcing rule (Adj Close, since bond ETFs distribute material monthly coupons), invariants, and test cases — parallel to the gold/commodities pattern

**Implementation** (\`src/backtester.py\`)
- \`LONG_BONDS_ETF = "TLT"\`, \`SHORT_BONDS_ETF = "SHY"\` constants
- \`_long_bonds_approximation\`, \`_short_bonds_approximation\` (preserves bitwise-identical pre-2002 behavior)
- \`_etf_total_returns\` reads \`Adj Close\` with \`Close\` fallback
- \`_build_long_bonds_returns\`, \`_build_short_bonds_returns\` use \`splice_returns\` to combine approximation + ETF
- Splice date is data-driven (first ETF trading day), not hardcoded
- \`build_asset_returns\` source labels for \`long_bonds\`/\`short_bonds\` now come from the helpers (per-day "^TNX"/"GS2_yield" pre-splice, "TLT"/"SHY" post-splice)

**Tests** (\`tests/test_bond_splicing.py\`, new file — 11 tests)
- Splice boundary tests for both bond assets
- Pre-2002 regression check (spliced returns equal an independently-computed approximation, atol=0)
- Post-splice monthly-return equality vs ETF
- Source label transitions exactly once per asset, no NaN labels on populated business days
- Adj Close vs Close discriminator (fixture has a step in Adj Close / Close ratio simulating a dividend ex-day; would fail if implementation read Close)
- Close-fallback test (omits Adj Close from fixture, verifies fallback)

## Spec adherence
- \`docs/specs/backtester.md\` updated first in commit \`5940772\`
- Implementation in commit \`23fafdd\` matches the spec
- Test strengthening in commit \`1dfb47d\` addresses pre-merge review nits

## Test plan
- [x] \`pytest tests/test_bond_splicing.py\` → 11 passed
- [x] \`pytest -m "not integration" -q\` → 27 passed (no regressions)
- [ ] After merge: rerun \`python scripts/validate_bond_returns.py\` against the real cache to confirm post-splice CAGR divergence ≈ 0 (since spliced data IS the ETF data over the overlap window)

## Known follow-ups (out of scope)
- Pre-2002 uncertainty surfacing in \`BacktestResult\` metadata (open question in the spec)
- Hybrid using ICE BofA Treasury indices for the 1990s validation window
- TIP splicing if/when TIPS become an asset class (#10)

Refs #31, #8