### PR TITLE
Data-quality surface on BacktestResult (resolves #31 open question)

### DIFF
--- a/specs/backtester.md
+++ b/specs/backtester.md
@@ -1,7 +1,7 @@
 # Backtester Specification
 
 Status: **Stabilizing**
-Last updated: 2026-04-14 (bond ETF splicing required by validation — see issues #8, #31)
+Last updated: 2026-04-14 (data-quality surface added to BacktestResult — resolves the pre-2002 uncertainty open question from #31)
 
 ## Purpose
 
@@ -196,12 +196,9 @@ preserve the same total-return semantics as the pre-splice series.
 
 ### Known open questions
 
-- **Pre-2002 uncertainty communication.** The 1975 → 2002-07-29 window
-  uses the duration approximation and has no ETF benchmark to bound its
-  error. The convexity-bias pattern observed post-2002 is likely also
-  present pre-2002 (rates fell sharply over 1981-1999). Surfacing this
-  in `BacktestResult` metadata so analysis can flag pre-2002 bond
-  exposure as approximation-only is open. Tracked separately.
+- ~~**Pre-2002 uncertainty communication.**~~ **Resolved** — see the
+  "Data quality" section below for `BacktestResult.asset_sources` and
+  `approximation_exposure()`.
 - **1990s hybrid.** ICE BofA Treasury indices on FRED extend the
   validation window earlier than TLT/SHY; could tighten the pre-2002
   estimate without requiring a third splice. Out of scope for #31.
@@ -341,6 +338,13 @@ class PortfolioSnapshot:
   - `turnover: pd.Series` — turnover (in [0, 1]) at each rebalance date
   - `costs: pd.Series` — transaction cost paid at each rebalance, in
     return units (cost / portfolio_value_at_rebalance)
+  - `asset_sources: pd.DataFrame` — same index and columns as
+    `asset_returns`; each cell holds the string source label that produced
+    that day's return for that asset (e.g., `"^TNX"`, `"TLT"`, `"GC=F"`,
+    `"WPUSI019011"`). Lifted from the `sources` DataFrame returned by
+    `build_asset_returns(..., return_sources=True)` so analysts can recover
+    the data quality of any backtest period without re-fetching. See "Data
+    quality" below for how this surfaces in analysis.
   - Config used
 
 ### Invariants
@@ -494,6 +498,87 @@ strategy backtest. Refinements can be added without changing the
 - Sortino ratio (downside deviation only)
 - Per-decade breakdown
 - Tax-adjusted return (short-term vs long-term gains)
+
+## Data quality
+
+### Purpose
+
+Some date ranges in the asset-returns frame come from model formulas
+rather than real prices. Backtests that lean heavily on those periods
+should be flagged so analysts don't compare strategies on apples-to-oranges
+data. This section defines what the spec considers "approximation only"
+and how that surfaces on `BacktestResult`.
+
+### Approximation sources
+
+The following source labels are derived from a model formula, not from
+real price or return data:
+
+- `^TNX` — `long_bonds` returns from the duration approximation
+  (1975 → 2002-07-29, before TLT splice)
+- `GS2_yield` — `short_bonds` returns from the duration approximation
+  (1975 → 2002-07-29, before SHY splice)
+
+Exposed as a module-level constant:
+
+```python
+APPROXIMATION_SOURCES: frozenset[str] = frozenset({"^TNX", "GS2_yield"})
+```
+
+**Proxy sources are NOT approximation sources.** FRED indices used in
+place of unavailable price series (`WPUSI019011` for gold, `PPIACO` and
+`DCOILWTICO` for commodities) are imperfect tracking of real data, not
+derived from a model. They have their own documented tracking error (see
+"Proxy series splicing → Known limitations") but the uncertainty class
+is different. Analysts who want to flag proxy exposure too can compose
+their own predicate against `BacktestResult.asset_sources` directly —
+the spec does not collapse the distinction.
+
+### `BacktestResult.approximation_exposure() -> pd.Series`
+
+Returns a series indexed by **rebalance dates** (matching
+`weights_history.index`), valued in `[0, 1]`. Each value is the fraction
+of portfolio weight at that rebalance allocated to assets whose source on
+that date is in `APPROXIMATION_SOURCES`. Useful for plotting alongside
+cumulative returns to show when a strategy leaned on approximated data.
+
+Defined at rebalance points rather than daily because (a) intra-rebalance
+weight drift is a small effect for the use case (flagging "is this result
+trustworthy?"), (b) it keeps the series cardinality manageable for
+plotting, and (c) it composes cleanly with the existing per-rebalance
+metadata (`weights_history`, `turnover`, `costs`).
+
+### Invariants
+
+- `asset_sources.index` equals `asset_returns.index`
+- `asset_sources.columns` equals `asset_returns.columns`
+- Every cell of `asset_sources` is a non-empty string on every business
+  day where `asset_returns` has a non-NaN value (no NaN, no empty)
+- `approximation_exposure()` returns values in `[0, 1]` for every entry
+- For a backtest entirely after 2002-07-30 with any bond weights,
+  `approximation_exposure()` is all zeros (post-splice; bond returns come
+  from TLT/SHY)
+- For a backtest with zero bond weights at every rebalance,
+  `approximation_exposure()` is all zeros regardless of period
+
+### Test cases
+
+- A backtest from 2010-01-01 with a 50/50 long_bonds/equities static
+  strategy has `approximation_exposure()` all zeros (post-splice)
+- A backtest from 1980-01-01 to 1985-12-31 with a 50/50
+  long_bonds/equities static strategy has `approximation_exposure()`
+  equal to 0.5 at every rebalance (pre-splice; bonds are pure
+  approximation)
+- A backtest spanning 2000-01-01 to 2005-12-31 with constant 100%
+  long_bonds shows `approximation_exposure()` transitioning from 1.0
+  (rebalances pre-2002-07-30) to 0.0 (rebalances post)
+- A backtest with a strategy that allocates 100% equities/cash at every
+  rebalance has `approximation_exposure()` all zeros, regardless of
+  period (no bond exposure)
+- Adding a new approximation source to `APPROXIMATION_SOURCES` and
+  rerunning a fixed backtest produces a strictly higher (or equal)
+  `approximation_exposure()` series — the metric is monotone in the
+  source set
 
 ---
 

--- a/src/backtester.py
+++ b/src/backtester.py
@@ -30,6 +30,10 @@ COMMODITIES_DAILY_TO_FUTURES_SPLICE = pd.Timestamp("2000-08-23")
 LONG_BONDS_ETF = "TLT"
 SHORT_BONDS_ETF = "SHY"
 
+# Source labels that correspond to model-derived (not price-derived) returns.
+# See specs/backtester.md → Data quality.
+APPROXIMATION_SOURCES: frozenset[str] = frozenset({"^TNX", "GS2_yield"})
+
 
 # ---------------------------------------------------------------------------
 # Transaction cost schedule (see specs/backtester.md, issue #6)
@@ -85,6 +89,38 @@ class BacktestResult:
     config: dict  # strategy config used
     turnover: pd.Series = field(default_factory=lambda: pd.Series(dtype=float))
     costs: pd.Series = field(default_factory=lambda: pd.Series(dtype=float))
+    asset_sources: pd.DataFrame = field(default_factory=pd.DataFrame)
+
+    def approximation_exposure(self) -> pd.Series:
+        """Fraction of portfolio weight in model-approximation sources at each rebalance.
+
+        See specs/backtester.md → Data quality. Returns a series indexed by
+        ``weights_history.index`` with values in ``[0, 1]``. Each value is the
+        sum of rebalance weights whose source label at that date is in
+        ``APPROXIMATION_SOURCES``. Degrades gracefully to zeros when no source
+        data was tracked.
+        """
+        if self.weights_history.empty:
+            return pd.Series(dtype=float)
+
+        if self.asset_sources.empty:
+            return pd.Series(
+                0.0, index=self.weights_history.index, dtype=float
+            )
+
+        exposures: list[float] = []
+        for date in self.weights_history.index:
+            row_weights = self.weights_history.loc[date]
+            row_sources = self.asset_sources.loc[date]
+            exposure = 0.0
+            for asset, weight in row_weights.items():
+                if asset in row_sources.index:
+                    source = row_sources[asset]
+                    if source in APPROXIMATION_SOURCES:
+                        exposure += float(weight)
+            exposures.append(exposure)
+
+        return pd.Series(exposures, index=self.weights_history.index, dtype=float)
 
 
 # ---------------------------------------------------------------------------
@@ -606,6 +642,7 @@ def run_backtest(
     rebalance_freq: str = "QE",  # quarterly rebalancing
     config: dict | None = None,
     cost_rate: float | Callable[[pd.Timestamp], float] = default_cost_schedule,
+    asset_sources: pd.DataFrame | None = None,
 ) -> BacktestResult:
     """
     Run a walk-forward backtest.
@@ -735,6 +772,11 @@ def run_backtest(
         turnover_series = pd.Series(dtype=float)
         cost_series = pd.Series(dtype=float)
 
+    if asset_sources is not None:
+        sliced_sources = asset_sources.loc[start_dt:]
+    else:
+        sliced_sources = pd.DataFrame()
+
     return BacktestResult(
         snapshots=snapshots,
         portfolio_returns=port_returns,
@@ -745,6 +787,7 @@ def run_backtest(
         config=config or {},
         turnover=turnover_series,
         costs=cost_series,
+        asset_sources=sliced_sources,
     )
 
 

--- a/tests/test_data_quality.py
+++ b/tests/test_data_quality.py
@@ -1,0 +1,260 @@
+"""Tests for the data-quality surface on ``BacktestResult``.
+
+Covers the test cases listed in ``specs/backtester.md`` under "Data quality".
+Tests use synthetic fixtures so they do not require a FRED API key or network
+access. The same synthetic construction shape as ``tests/test_bond_splicing.py``
+is used so pre/post-2002 splice behavior can be exercised deterministically.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from src import backtester as backtester_mod
+from src.backtester import (
+    APPROXIMATION_SOURCES,
+    LONG_BONDS_ETF,
+    SHORT_BONDS_ETF,
+    BacktestResult,
+    StaticStrategy,
+    build_asset_returns,
+    run_backtest,
+)
+
+
+# ---------------------------------------------------------------------------
+# Synthetic fixture construction (mirrors tests/test_bond_splicing.py)
+# ---------------------------------------------------------------------------
+
+TLT_SPLICE = pd.Timestamp("2002-07-30")
+SHY_SPLICE = pd.Timestamp("2002-07-30")
+
+
+def _business_days(start: str, end: str) -> pd.DatetimeIndex:
+    return pd.bdate_range(start=start, end=end)
+
+
+def _make_price_df(
+    index: pd.DatetimeIndex,
+    start_price: float = 100.0,
+    drift: float = 0.0002,
+    seed: int = 0,
+    include_close: bool = True,
+) -> pd.DataFrame:
+    rng = np.random.default_rng(seed)
+    rets = rng.normal(drift, 0.005, size=len(index))
+    adj = start_price * np.cumprod(1.0 + rets)
+    data = {"Adj Close": adj}
+    if include_close:
+        data["Close"] = adj * 0.9
+    return pd.DataFrame(data, index=index)
+
+
+def _make_yield_df(
+    index: pd.DatetimeIndex,
+    start_yield_pct: float = 7.5,
+    drift: float = 0.0,
+    vol: float = 0.02,
+    seed: int = 0,
+) -> pd.DataFrame:
+    rng = np.random.default_rng(seed)
+    rets = rng.normal(drift, vol, size=len(index))
+    levels = start_yield_pct * np.cumprod(1.0 + rets)
+    levels = np.clip(levels, 0.5, 20.0)
+    return pd.DataFrame({"Close": levels}, index=index)
+
+
+@pytest.fixture
+def trading_index() -> pd.DatetimeIndex:
+    return _business_days("1975-01-01", "2015-12-31")
+
+
+@pytest.fixture
+def synthetic_data(trading_index: pd.DatetimeIndex) -> dict:
+    """Minimal synthetic ``data`` dict spanning both pre- and post-splice periods."""
+    tnx = _make_yield_df(trading_index, start_yield_pct=7.5, vol=0.015, seed=101)
+    gs2_daily = _make_yield_df(
+        trading_index, start_yield_pct=6.0, vol=0.02, seed=102
+    )
+    gs2_series = gs2_daily["Close"].rename("GS2_yield")
+
+    etf_idx = _business_days("2002-07-30", "2015-12-31")
+    tlt = _make_price_df(etf_idx, start_price=90.0, drift=0.0001, seed=201)
+    shy = _make_price_df(etf_idx, start_price=80.0, drift=0.00005, seed=202)
+
+    sp = _make_price_df(
+        trading_index, start_price=70.0, drift=0.0003, seed=15, include_close=False
+    )
+    sp["Close"] = sp["Adj Close"]
+
+    fed = pd.Series(
+        5.0,
+        index=pd.date_range("1975-01-01", "2015-12-01", freq="MS"),
+        name="FEDFUNDS",
+    )
+
+    return {
+        "^GSPC": sp,
+        "^TNX": tnx,
+        "GS2_yield": gs2_series,
+        "FEDFUNDS": fed,
+        LONG_BONDS_ETF: tlt,
+        SHORT_BONDS_ETF: shy,
+    }
+
+
+def _run(
+    synthetic_data: dict,
+    strategy,
+    start: str,
+    end: str | None = None,
+) -> BacktestResult:
+    """Run a backtest with sources wired in; optionally trim asset_returns to ``end``."""
+    returns, sources = build_asset_returns(
+        synthetic_data, start="1975-01-01", return_sources=True
+    )
+    if end is not None:
+        end_dt = pd.Timestamp(end)
+        returns = returns.loc[:end_dt]
+        sources = sources.loc[:end_dt]
+    return run_backtest(
+        strategy=strategy,
+        asset_returns=returns,
+        indicator_data={},
+        start=start,
+        asset_sources=sources,
+        cost_rate=0.0,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Spec test cases
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+@pytest.mark.spec
+def test_approximation_exposure_post_splice_is_zero(synthetic_data):
+    """specs/backtester.md "Data quality → Test cases":
+    a backtest from 2010-01-01 with 50/50 long_bonds/equities has exposure 0."""
+    strat = StaticStrategy({"long_bonds": 0.5, "equities": 0.5})
+    result = _run(synthetic_data, strat, start="2010-01-01")
+
+    exposure = result.approximation_exposure()
+    assert len(exposure) > 0
+    np.testing.assert_allclose(exposure.values, 0.0, atol=1e-12)
+
+
+@pytest.mark.unit
+@pytest.mark.spec
+def test_approximation_exposure_pre_splice_full(synthetic_data):
+    """specs/backtester.md "Data quality → Test cases":
+    1980 → 1985 with 50/50 long_bonds/equities has exposure 0.5 everywhere
+    (long bonds come from the ^TNX approximation pre-splice)."""
+    strat = StaticStrategy({"long_bonds": 0.5, "equities": 0.5})
+    result = _run(synthetic_data, strat, start="1980-01-01", end="1985-12-31")
+
+    exposure = result.approximation_exposure()
+    assert len(exposure) > 0
+    np.testing.assert_allclose(exposure.values, 0.5, atol=1e-12)
+
+
+@pytest.mark.unit
+@pytest.mark.spec
+def test_approximation_exposure_transitions_at_splice(synthetic_data):
+    """specs/backtester.md "Data quality → Test cases":
+    2000 → 2005 with 100% long_bonds transitions from 1.0 to 0.0 at 2002-07-30."""
+    strat = StaticStrategy({"long_bonds": 1.0})
+    result = _run(synthetic_data, strat, start="2000-01-01", end="2005-12-31")
+
+    exposure = result.approximation_exposure()
+    pre = exposure[exposure.index < TLT_SPLICE]
+    post = exposure[exposure.index >= TLT_SPLICE]
+
+    assert len(pre) > 0 and len(post) > 0
+    np.testing.assert_allclose(pre.values, 1.0, atol=1e-12)
+    np.testing.assert_allclose(post.values, 0.0, atol=1e-12)
+
+
+@pytest.mark.unit
+@pytest.mark.spec
+def test_approximation_exposure_zero_for_no_bond_strategy(synthetic_data):
+    """specs/backtester.md "Data quality → Invariants":
+    zero bond weight at every rebalance => exposure is all zeros regardless of period."""
+    strat = StaticStrategy({"equities": 1.0})
+    result = _run(synthetic_data, strat, start="1985-01-01", end="1995-12-31")
+
+    exposure = result.approximation_exposure()
+    assert len(exposure) > 0
+    np.testing.assert_allclose(exposure.values, 0.0, atol=1e-12)
+
+
+@pytest.mark.unit
+@pytest.mark.spec
+def test_approximation_exposure_monotone_in_source_set(
+    synthetic_data, monkeypatch
+):
+    """specs/backtester.md "Data quality → Test cases":
+    adding a new source to APPROXIMATION_SOURCES produces an element-wise
+    greater-or-equal exposure series on a fixed backtest."""
+    strat = StaticStrategy({"long_bonds": 0.5, "equities": 0.5})
+    baseline = _run(synthetic_data, strat, start="1990-01-01", end="1995-12-31")
+    base_exposure = baseline.approximation_exposure()
+
+    extended = APPROXIMATION_SOURCES | {"^GSPC"}
+    monkeypatch.setattr(backtester_mod, "APPROXIMATION_SOURCES", extended)
+
+    extended_exposure = baseline.approximation_exposure()
+
+    assert (extended_exposure.values >= base_exposure.values - 1e-12).all()
+    # With equities (^GSPC) added, and 50% equities weight, the extended
+    # exposure should be strictly greater than baseline.
+    assert (extended_exposure.values > base_exposure.values + 1e-6).all()
+
+
+@pytest.mark.unit
+@pytest.mark.spec
+def test_asset_sources_invariants(synthetic_data):
+    """specs/backtester.md "Data quality → Invariants":
+    asset_sources.index == asset_returns.index, columns match, no NaN/empty
+    cells on populated business days."""
+    strat = StaticStrategy({"long_bonds": 0.5, "equities": 0.5})
+    result = _run(synthetic_data, strat, start="1980-01-01", end="2005-12-31")
+
+    pd.testing.assert_index_equal(
+        result.asset_sources.index, result.asset_returns.index
+    )
+    assert list(result.asset_sources.columns) == list(result.asset_returns.columns)
+
+    populated = result.asset_returns.notna()
+    source_populated = result.asset_sources.notna() & (result.asset_sources != "")
+    # Every cell populated in returns must have a non-empty source label.
+    missing = populated & ~source_populated
+    assert not missing.values.any(), (
+        f"asset_sources has NaN/empty cells where asset_returns is populated: "
+        f"{missing.sum().to_dict()}"
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.spec
+def test_run_backtest_default_asset_sources_empty(synthetic_data):
+    """specs/backtester.md "Data quality":
+    when run_backtest is called without asset_sources, result.asset_sources is
+    empty and approximation_exposure() returns zeros indexed by weights_history."""
+    returns = build_asset_returns(synthetic_data, start="1975-01-01")
+    strat = StaticStrategy({"long_bonds": 0.5, "equities": 0.5})
+    result = run_backtest(
+        strategy=strat,
+        asset_returns=returns,
+        indicator_data={},
+        start="1980-01-01",
+        cost_rate=0.0,
+    )
+
+    assert result.asset_sources.empty
+
+    exposure = result.approximation_exposure()
+    pd.testing.assert_index_equal(exposure.index, result.weights_history.index)
+    np.testing.assert_allclose(exposure.values, 0.0, atol=1e-12)


### PR DESCRIPTION
## Summary

Resolves the "Pre-2002 uncertainty communication" open question left over from #38 (bond ETF splicing).

## Changes

**Spec** (\`specs/backtester.md\`)
- Adds \`asset_sources\` field to \`BacktestResult\`'s "Outputs" list — same shape as \`asset_returns\`, holds per-day per-asset source labels lifted from \`build_asset_returns(..., return_sources=True)\`
- New "Data quality" section: defines \`APPROXIMATION_SOURCES = frozenset({"^TNX", "GS2_yield"})\`, the \`approximation_exposure()\` method, invariants, and 5 spec test cases
- Marks the corresponding open question in "Bond return approximation → Known open questions" as resolved

**Implementation** (\`src/backtester.py\`)
- \`APPROXIMATION_SOURCES\` module-level constant
- \`asset_sources: pd.DataFrame\` field on \`BacktestResult\` (default empty for back-compat)
- \`approximation_exposure() -> pd.Series\` method, indexed by rebalance dates, valued in [0, 1], with graceful degradation when \`asset_sources\` is empty
- \`run_backtest\` accepts \`asset_sources: pd.DataFrame | None = None\` and slices to \`start_dt:\` when provided

**Tests** (\`tests/test_data_quality.py\`, new — 7 tests)
- Post-splice exposure all zeros
- Pre-splice exposure 0.5 for 50/50 strategy
- Transition at the splice date (1.0 → 0.0 for 100% long_bonds spanning 2000-2005)
- Zero exposure for no-bond strategies regardless of period
- Monotonicity in the source set (monkeypatch-based)
- \`asset_sources\` shape and no-NaN invariants
- Default-empty back-compat (no \`asset_sources\` arg → empty field, zero exposure)

## Why this design

- Defined at rebalance points rather than daily — the use case is "flag results that lean on approximated data", and intra-rebalance drift is a small effect for that question. Keeps cardinality manageable for plotting too.
- Proxy sources (\`WPUSI019011\`, \`PPIACO\`, \`DCOILWTICO\`) are deliberately NOT in \`APPROXIMATION_SOURCES\`. They're imperfect tracking of real data, not derived from a model formula. Different uncertainty class — analysts who care about proxy exposure can compose their own predicate against \`asset_sources\` directly.
- Default \`asset_sources=None\` keeps every existing call site (notebooks, scripts) working unchanged. Wiring up the new surface is opt-in.

## Pre-merge review

Run via review agent. Verdict: **PASS**, no findings. Spec→test coverage matrix shows VERIFIED for all 5 spec test cases plus the two implementation-detail tests.

## Test plan

- [x] \`.venv/bin/pytest tests/test_data_quality.py -v\` → 7 passed
- [x] \`.venv/bin/pytest tests/test_bond_splicing.py -q\` → 11 passed (no regression)
- [x] \`.venv/bin/pytest -m "not integration" -q\` → 34 passed (was 27; +7 new)
- [ ] After merge: a notebook run that wires up \`asset_sources\` and plots \`approximation_exposure()\` alongside cumulative returns to confirm the analyst use case works end-to-end (out of scope for this PR — implementation is complete, integration into existing notebooks is a follow-up)

Refs #31