### PR TITLE
Review verdict propagates to PR comment + merge commit body

### DIFF
--- a/.claude/agents/review-pr.md
+++ b/.claude/agents/review-pr.md
@@ -96,3 +96,31 @@ If applicable, a **Spec→test coverage matrix**: for each test case in the rele
 `<spec test case phrasing> — <test function name> — VERIFIED | WEAK | MISSING`
 
 Do not recommend changes unless they're required to meet the spec. This is a spec-conformance review, not a code-improvement session.
+
+## Embedded review block (REQUIRED)
+
+After the freeform analysis above, append a final section formatted EXACTLY as below. This block is the durable artifact — the coordinator will paste it verbatim into a PR comment and into the merge commit body so the review is permanently attached to the PR thread and to git history.
+
+Keep the block self-contained: a future reader looking at the merge commit a year from now should understand what changed and what the review found, without needing the rest of your freeform analysis.
+
+```markdown
+## Pre-merge review
+
+**Verdict:** PASS | PASS-WITH-NITS | CHANGES-REQUIRED | BLOCKED
+
+**Reviewed:** <one-line characterization of what the PR changes — e.g., "Splice TLT/SHY for long_bonds/short_bonds 2002+; spec + impl + 11 tests">
+
+**Spec conformance:** <verified against which specs, in one sentence; or "no spec applies" for exploring/docs PRs>
+
+**Findings:**
+- Critical: <none | bullets>
+- Major: <none | bullets>
+- Minor: <none | bullets>
+- Nit: <none | bullets>
+
+**Tests:** <counts before/after, e.g., "27 → 34 unit, 0 → 3 integration, all passing">
+
+_Reviewed independently by the `review-pr` subagent. Verdict is independent of the author's PR description._
+```
+
+Use literal `none` (not "N/A" or empty) for severity buckets with no findings, so the section reads consistently. If a finding is too long for a bullet, summarize it in the bullet and reference the freeform analysis above.

--- a/.claude/commands/review-pr.md
+++ b/.claude/commands/review-pr.md
@@ -23,10 +23,42 @@ Steps:
 
    The agent's body has the full review prompt. Your job here is just to hand it the inputs (PR number, relevant specs) and any optional context (e.g., a commit range if the PR is multi-commit and worth reviewing commit-by-commit).
 
-3. When the agent returns its verdict:
+3. The agent's report ends with an **embedded review block** (a markdown section starting with `## Pre-merge review`). Extract that block verbatim — you'll use it twice in the next steps. Do NOT paraphrase or edit it; the agent's wording is the durable record.
+
+4. **Post the embedded block as a PR comment immediately**, regardless of verdict, so the review is visible in the PR thread before the merge decision:
+
+   ```
+   gh pr comment $ARGUMENTS --body "<embedded block contents>"
+   ```
+
+   Use a heredoc to preserve markdown formatting:
+
+   ```
+   gh pr comment $ARGUMENTS --body "$(cat <<'EOF'
+   ## Pre-merge review
+   ...
+   EOF
+   )"
+   ```
+
+   Posting before the merge decision means CHANGES-REQUIRED and BLOCKED reviews are also captured on the PR thread for the author / future readers.
+
+5. Decide based on verdict:
    - **PASS** → ask the user if they want to merge
    - **PASS-WITH-NITS** → summarize the nits and ask the user whether to merge or fix first
-   - **CHANGES-REQUIRED** → summarize the blocking issues; do NOT offer to merge; either delegate a coding agent to fix or ask the user to redirect
+   - **CHANGES-REQUIRED** → do NOT offer to merge; either delegate a coding agent to fix or ask the user to redirect. The PR comment is now visible to the author.
    - **BLOCKED** → report what is blocked and ask the user how to proceed
 
-Do NOT merge the PR yourself based on the verdict alone. The human makes the merge decision; your job is to surface the review findings.
+6. **On user's merge approval**, include the same embedded block in the merge commit body so the review is preserved in git history (PR comments live on GitHub; merge commit bodies live in the repo forever):
+
+   ```
+   gh pr merge $ARGUMENTS --merge --body "$(cat <<'EOF'
+   ## Pre-merge review
+   ...
+   EOF
+   )"
+   ```
+
+   Same block, same formatting. Two places, one source of truth.
+
+Do NOT merge the PR yourself based on the verdict alone. The human makes the merge decision; your job is to surface the review findings and propagate the verdict to the durable artifacts (PR comment + merge commit) once they decide.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -171,7 +171,7 @@ If you (the coordinator) catch yourself reaching for `Edit` or `Write` on a deny
 4. Coordinator delegates to a review agent to check implementation against spec
 5. Coordinator reviews findings, approves or sends back
 6. Coordinator pushes the branch and opens a pull request (never merges locally to main)
-7. Before merging, coordinator runs a **pre-merge review** of the PR — either via `/review-pr <number>` (which delegates to the `review-pr` subagent defined at `.claude/agents/review-pr.md`) or by spawning the agent directly with `Agent(subagent_type="review-pr", ...)`. Merge only on PASS or PASS-WITH-NITS (see #15 for the Level 1/2/3 escalation path toward CI enforcement)
+7. Before merging, coordinator runs a **pre-merge review** of the PR — either via `/review-pr <number>` (which delegates to the `review-pr` subagent defined at `.claude/agents/review-pr.md`) or by spawning the agent directly with `Agent(subagent_type="review-pr", ...)`. The agent's report ends with an embedded `## Pre-merge review` block; the coordinator (or `/review-pr`) posts that block verbatim as a PR comment immediately, and on merge approval includes the same block in the merge commit body via `gh pr merge --body`. Same review lands in two durable places: the PR thread on GitHub (visible to author and future readers) and the merge commit (permanent, surfaces in `git log`). Merge only on PASS or PASS-WITH-NITS (see #15 for the Level 1/2/3 escalation path toward CI enforcement)
 8. Work is landed by merging the PR — this preserves a reviewable artifact, keeps a searchable history, and gives CI and the review agent a surface to hook into
 
 **Coding agents work in the main checkout, not worktrees.** Earlier versions of


### PR DESCRIPTION
## Summary

The pre-merge review verdict has been a private artifact of the coordinator's session — future readers of PR history saw only the author's summary, not the independent review. This change closes that loop.

## Changes

- \`.claude/agents/review-pr.md\` — appends an "embedded review block" requirement to the agent's report format. The block is a structured markdown section (verdict, what was reviewed, spec conformance, findings by severity, tests) intended to be pasted verbatim into PR comments and merge commits.
- \`.claude/commands/review-pr.md\` — the slash command now extracts that block from the agent's report and posts it as a PR comment via \`gh pr comment\` immediately (regardless of verdict). On user merge approval, the same block goes into the merge commit body via \`gh pr merge --body\`.
- \`CLAUDE.md\` workflow step 7 — documents the new convention.

## Why two attach points

- **PR comment** — visible in the PR thread on GitHub, searchable, captures the review for the author even if verdict is CHANGES-REQUIRED (no merge happens but the review is preserved).
- **Merge commit body** — permanent git-history record. PR comments can be lost if the repo is migrated/archived; commit messages stay forever.

Same content in both places. One source of truth: the agent writes the block once, the slash command propagates it.

## Test plan

- [ ] Next session, run \`/review-pr <some-PR>\` and verify the agent emits the embedded block
- [ ] Verify \`gh pr comment\` posts the block correctly
- [ ] Verify \`gh pr merge --body\` includes it in the merge commit
- [ ] (Manual dogfood for THIS session: the review-pr agent definition is loaded at session start, so changes don't take effect until next session — coordinator can manually run the new format on PRs in this session by spawning a general-purpose agent with the embedded-block prompt instructions)