### PR TITLE
Governance sharpening: branch-prefix file-type heuristic + review-pr gate

### DIFF
--- a/.claude/agents/review-pr.md
+++ b/.claude/agents/review-pr.md
@@ -31,6 +31,23 @@ Then read each relevant spec file in full before evaluating conformance. Do not 
 
 ## What to verify
 
+### 0. Governance gate — branch prefix and spec coverage (run this FIRST)
+
+Before checking code-against-spec, verify the PR should have a spec in the first place. Silently PASSing a PR that violates spec-first governance is the failure mode this check prevents.
+
+**File-type heuristic (hard rule per CLAUDE.md Workflow section).** Any PR creating or modifying files in `src/`, `tests/`, or `configs/` is stabilizing by default, regardless of branch prefix or how exploratory the research intent feels. Work that is purely `notebooks/`, `docs/research/`, or `data/` may be exploratory and spec-exempt.
+
+**Check:**
+
+- Does the diff touch `src/`, `tests/`, or `configs/`? (Ignore `.vscode/` and other transient dev-environment files.)
+- If yes, identify which spec(s) under `specs/` govern the touched area. The spec may be pre-existing or authored in this PR's commits.
+- If no spec exists covering the touched area: this is a CHANGES-REQUIRED governance finding. Do NOT silently PASS — the rest of the review has no contract to check against. Surface the finding explicitly and cite CLAUDE.md's Workflow-section rule.
+- If the branch prefix is `explore/` but the diff touches `src/`, `tests/`, or `configs/`: flag as a governance mismatch even if a spec exists. `explore/` MUST NOT contain stabilizing-surface changes.
+
+**One-time-exception clause.** If the PR body explicitly acknowledges a governance exception — e.g., "spec authoring follow-up coming in PR #X, coordinator has approved this exception" — note the exception as a Major finding with a citation to the follow-up, allow the review to proceed on the remaining sections, but do NOT quietly absorb the exception. The durable review block must name it so the PR thread and merge commit record the exception for future reference.
+
+Report this check's result at the top of the findings section before proceeding to specs conformance.
+
 ### 1. Spec conformance
 
 For each spec the caller listed:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,10 +102,19 @@ you're about to stabilize, write the spec BEFORE the refactor.
   and add a test. The spec grows from real failures, not hypothetical ones.
 - **Every PR touching a specced component** should reference the relevant spec and
   note whether the spec was updated as part of the change.
+- **At delegation time:** before spawning a coding agent, the coordinator MUST
+  state the branch prefix in the delegation prompt and the rationale. If the
+  prefix is `stable/`, the spec MUST exist before the implementation delegation
+  (not written concurrently). The coordinator's first commit on a `stable/`
+  branch MUST be the spec; implementation delegations follow. This is enforced
+  by the file-type rule in the Workflow section — tests or `src/` code in a
+  delegation prompt mean `stable/` and spec-first, no exceptions.
 
 ### Theses inform specs
 
 `specs/theses/` holds project theses — claims about how the world works that shape which components get built and how results are interpreted. Theses are NOT specs (they're not code contracts) but they're upstream of them: a bond-allocation thesis shapes what BigCycleStrategy's base weights should look like; the backtest-sample-scope thesis shapes how backtest results should be framed in `docs/research/*.md`.
+
+The theses in this directory are organized as an **umbrella thesis** with sub-theses that compose it, plus peer-level **counter-theses** that oppose it. The umbrella lives at `specs/theses/changing-world-order/` (the Dalio-inspired worldview); sub-theses are files in that folder; counter-theses sit at the top level of `specs/theses/`. See `specs/theses/README.md` for structure and `specs/theses/changing-world-order/dalio-principles.md` for the reference catalog of Dalio's specific modeling specifications the project builds against. Stance: **Dalio-inspired, not Dalio-faithful** — scaffolding accepted where useful, departures named explicitly. **Paired evidence tracking is load-bearing**: new data updates both the umbrella's evidence log AND any relevant counter-thesis, symmetrically.
 
 - **Before running an experiment** — check `specs/theses/` to see what claim it's testing. If you're about to test something whose thesis isn't in there, consider whether it should be — new theses come up during research.
 - **When a test produces results** — update the relevant thesis's "Current evidence" section. Don't overwrite prior entries; build the evidence log. Note the scale (cyclical / secular / transition) the test addresses.
@@ -165,12 +174,25 @@ branches locally to main — always land changes via a pull request.**
 
 | Branch prefix | Purpose | Spec required? |
 |---------------|---------|----------------|
-| `explore/{phase}/{feature}` | Exploratory work — notebooks, new indicators, prototypes | No |
+| `explore/{phase}/{feature}` | Exploratory work — notebooks, research notes, prototypes | No |
 | `stable/{phase}/{feature}` | Stabilization — spec must be updated before implementation, tests required | Yes |
 | `fix/{description}` | Bug fixes — update spec if the bug revealed a missing invariant | If specced |
 | `docs/{description}` | Documentation, specs, CLAUDE.md changes | N/A |
 
 Examples: `explore/phase1/civilizational-indicators`, `stable/phase2/regime-classifier`, `fix/walk-forward-leak`
+
+**How to choose `explore/` vs `stable/` — file-type heuristic (hard rule).**
+
+The "about to be depended on by other components" criterion in the spec lifecycle is soft and has been misapplied (see governance-miss note below). Replace it with a file-type rule:
+
+- **Any PR that creates or modifies files in `src/`, `tests/`, or `configs/` is stabilizing by default**, regardless of how exploratory the research intent feels. Such PRs MUST use `stable/` and the spec MUST be written first.
+- `explore/` MUST be used only when the work is purely in `notebooks/`, `docs/research/`, or `data/`.
+- If a single stream of work needs both — a research notebook AND a new data-fetcher module — it MUST be split into two PRs: one `explore/` for the analytical output, one `stable/` for the infrastructure. Different branches, different review standards.
+- Mixed-scope in one PR is permitted only with explicit justification in the PR body and coordinator sign-off. The default is split.
+
+The goal of this rule: coordinator judgment is no longer required to decide "is this exploratory?" The decision is answered by looking at the diff's file paths. Tests alone (even if you feel the work is exploratory) are implicit stable-contract claims — exploratory work doesn't need them.
+
+**Governance-miss note (2026-04-15):** Phase A of issue #52 was delegated to `explore/uk-sterling-transition` when the work created `src/data_fetcher_uk.py`, `configs/series_uk.yaml`, `scripts/fetch_uk_data.py`, and `tests/test_uk_data_fetcher.py`. Per the file-type rule above, it should have been `stable/phase2/uk-data-pipeline` with a spec authored first. The coordinator accepted this miss explicitly, preserved the exploratory implementation as `archive/uk-phase-a-no-spec-2026-04-15`, and re-did the stabilization under the new regime. The re-do is the test of this rule's value; the archive and `docs/research/spec-driven-vs-exploratory-uk-phase-a.md` are the comparison artifacts.
 
 **Tracking:** Bugs, features, and tasks are GitHub issues at dsdale24/big-cycle-investing.
 Labels: `exploring`, `stabilizing`, `bug`, `data`. See issue #13 for the full roadmap.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,8 +107,9 @@ you're about to stabilize, write the spec BEFORE the refactor.
   prefix is `stable/`, the spec MUST exist before the implementation delegation
   (not written concurrently). The coordinator's first commit on a `stable/`
   branch MUST be the spec; implementation delegations follow. This is enforced
-  by the file-type rule in the Workflow section — tests or `src/` code in a
-  delegation prompt mean `stable/` and spec-first, no exceptions.
+  by the file-type rule in the Workflow section — tests, `src/` code, or
+  `configs/` changes in a delegation prompt mean `stable/` and spec-first, no
+  exceptions.
 
 ### Theses inform specs
 

--- a/specs/theses/README.md
+++ b/specs/theses/README.md
@@ -48,6 +48,8 @@ When recording a thesis test result, always state **which scale(s) it addresses*
 - **`falsified`** — evidence contradicts the claim at a relevant scale (always say which)
 - **`refined`** — superseded by a sharper version (link forward)
 - **`confirmed`** — tested across multiple scales or via strong cross-national evidence with consistent results (rare; high bar)
+- **`forthcoming`** — thesis has been filed as an issue but not yet drafted; no claim body, no evidence log. Placeholder status used in index tables to signal pre-draft state (the issue link in the index row tells you what's coming). Not applied to thesis files themselves — a file's status should always be one of the substantive values above.
+- **`stub (forthcoming)`** — thesis file exists but is minimally articulated; structure is present (empty evidence log, placeholder claim and falsification) but the argument is a sketch. A stub promoted to full draft gets status `active` and loses the parenthetical.
 
 The body of each thesis is more important than the status label. A one-word status can't capture scale-conditional results; the prose must.
 

--- a/specs/theses/changing-world-order/dalio-principles.md
+++ b/specs/theses/changing-world-order/dalio-principles.md
@@ -205,7 +205,7 @@ Bridgewater itself reports strategy performance by decomposing into these four e
 - US is in **Stage 5 of the 6-stage empire cycle**, transitioning toward Stage 6
 - US is in **Stage 4 of a 4-stage public-debt bust** (the final stage before resolution)
 - **Specific policy threshold:** deficit must fall from current ~6% of GDP to ~3% of GDP sustained to avoid late-stage resolution
-- **Prediction (per 2026 Fortune interview):** "double-digit interest rates and a sharp (30-50 percent) plunge in government bond prices in the coming decade" if deficit trajectory doesn't change
+- **Prediction (as reported in the Fortune 2026-03-14 interview):** Dalio, per the interviewer's paraphrase and partial quotation, said that unless deficits are reduced, the US could experience "double-digit interest rates and a sharp (30-50 percent) plunge in government bond prices" in the coming decade. This reaches the project through a journalist's reporting, not a Dalio-authored primary source — a direct primary-source quote at the same sharpness has not been located in this session's research. Attribution should be tightened if a primary source surfaces.
 
 **Sources.**
 - *Changing World Order* (2021), Ch. 2 for base-rate framing


### PR DESCRIPTION
## Summary

Structural fix for the governance miss observed 2026-04-15: Phase A of #52 was delegated to `explore/uk-sterling-transition` when the work created `src/`, `tests/`, and `configs/` files (i.e., stabilizing-surface changes that require a spec first). The miss was not attentional — the rule was soft (\"about to be depended on by other components\") and was misapplied under a defensible but wrong reading.

This PR hardens the rule, adds a review-pr governance gate as a safety net, and bundles the three nits from PR #87's review.

## What changed

**Fix 1: File-type heuristic for branch-prefix choice (CLAUDE.md Workflow section).**

New hard rule replacing the soft criterion:
- Any PR modifying `src/`, `tests/`, or `configs/` MUST use `stable/`, and the spec MUST be written first
- `explore/` MUST be used only for work purely in `notebooks/`, `docs/research/`, or `data/`
- Mixed-scope work MUST be split into two PRs (one per branch type)

The decision is now answered by looking at diff file paths, not by coordinator judgment.

**Fix 2: Delegation-time discipline (CLAUDE.md spec-driven development section).**

New bullet: coordinator MUST state the branch prefix in every delegation prompt. For `stable/` delegations, the spec MUST exist before the implementation is delegated; first commit on a `stable/` branch MUST be the spec.

**Fix 3: review-pr gains a governance gate as §0, runs FIRST.**

New section in `.claude/agents/review-pr.md` that checks spec coverage against the file-type heuristic before any other review work. Raises CHANGES-REQUIRED if `src/`, `tests/`, or `configs/` changes land without a covering spec. One-time-exception clause for explicit coordinator-approved exceptions, which are flagged as Major (never silently absorbed).

## PR #87 nits bundled

- **`forthcoming` / `stub (forthcoming)` status vocabulary** added to `specs/theses/README.md` with explicit pre-draft semantics
- **CLAUDE.md \"Theses inform specs\" section** now names the umbrella / sub-theses / counter-theses structure directly, removing the one-hop discoverability issue
- **`dalio-principles.md` §10 Fortune-interview hedging tightened** — prediction is now framed as interviewer's paraphrase, not direct Dalio quote, with note that attribution should tighten if a primary source surfaces

## Language discipline

Binding rules use MUST per RFC 2119 convention. Advisory guidance (e.g., \"attribution should tighten if a primary source surfaces\") uses SHOULD. The governance gate needs to be unambiguous about what is negotiable and what is not — mixing SHOULD and MUST in binding rules was a prior weakness.

## Why now

This lands BEFORE the UK pipeline re-do so:
1. The re-do (on `stable/phase2/uk-data-pipeline`) is reviewed under the new regime — it will be the first real test of the new rule
2. The experiment of comparing spec-driven vs exploratory implementation is cleanly scoped (archived implementation at `archive/uk-phase-a-no-spec-2026-04-15`; spec-first implementation on new branch)

## Test plan

- [ ] CLAUDE.md Workflow section renders cleanly
- [ ] review-pr agent's §0 fires on any future PR that would skip a spec
- [ ] `forthcoming` vocabulary entries are referenced by the index tables in `specs/theses/README.md`
- [ ] `dalio-principles.md` §10 hedging reads correctly

Meta: running `/review-pr` on this PR is the first test of whether the new governance gate is self-consistent. Since this PR is pure docs/specs (no `src/`, `tests/`, or `configs/`), the gate should PASS at §0 and proceed to standard review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)