### PR TITLE
UK pipeline: expand series 17 → 30 (#52 Phase A series expansion)

### DIFF
--- a/configs/series_uk.yaml
+++ b/configs/series_uk.yaml
@@ -281,7 +281,7 @@ uk:
     start_year: 1791
     end_year: 2016
     publication_lag_days: 0
-    description: USD/GBP exchange rate (USD per GBP), calendar-year average. Carried as a distinct key from uk_gbp_usd for per-use convenience per specs/data_pipeline/uk.md §"Required target-series coverage". The BoE workbook exposes only "$/£" (USD per GBP) directly; both keys point at the same source column. Inverting to GBP per USD for consumers that expect that convention belongs in a derived-indicators layer, not the registry.
+    description: USD per GBP (e.g., ~$4.86 at classical parity), calendar-year average. This is the direction the BoE workbook stores natively in the "$/£" column; GBP/USD is derivable as 1/x in consumer code. Inverting to GBP per USD for consumers that expect that convention belongs in a derived-indicators layer, not the registry.
     status: available
 
   uk_real_usd_gbp_rate:

--- a/configs/series_uk.yaml
+++ b/configs/series_uk.yaml
@@ -77,6 +77,22 @@ uk:
     description: Public sector total receipts (tax + other revenue) as % of nominal GDP.
     status: available
 
+  uk_public_spending_gdp:
+    name: UK Public Sector Total Managed Expenditure (% GDP)
+    category: fiscal
+    frequency: annual
+    source_sheet: "A1. Headline series"
+    source_column: "Public sector Total Managed Expenditure"
+    source_column_units: "as a % of nominal GDP"
+    source_header_row: 3
+    source_units_row: 5
+    source_year_start_row: 7
+    start_year: 1900
+    end_year: 2016
+    publication_lag_days: 0
+    description: UK public sector total managed expenditure (TME) as % of nominal GDP. Government-spending-to-GDP ratio; complements the receipts series for a full fiscal stance picture.
+    status: available
+
   # --- Monetary ---
   uk_bank_rate:
     name: UK Bank Rate (year-end)
@@ -108,6 +124,55 @@ uk:
     end_year: 2016
     publication_lag_days: 0
     description: UK consumer price inflation (year-on-year, %). BoE-curated long series combining historical cost-of-living indices with modern CPI.
+    status: available
+
+  uk_cpi:
+    name: UK Consumer Price Index
+    category: monetary
+    frequency: annual
+    source_sheet: "A1. Headline series"
+    source_column: "Consumer price index"
+    source_column_units: "2015=100"
+    source_header_row: 3
+    source_units_row: 5
+    source_year_start_row: 7
+    start_year: 1209
+    end_year: 2016
+    publication_lag_days: 0
+    description: UK consumer price index level (2015=100). BoE-curated long price level composite; inflation rate is derivable but level is the primary measurement needed for real-value deflation (real wages, real asset prices).
+    status: available
+
+  uk_monetary_base:
+    name: UK Monetary Base (M0)
+    category: monetary
+    frequency: annual
+    source_sheet: "A1. Headline series"
+    source_column: "Monetary base"
+    source_column_units: "Year end, £mn"
+    source_header_row: 3
+    source_units_row: 5
+    source_year_start_row: 7
+    start_year: 1833
+    end_year: 2016
+    publication_lag_days: 0
+    description: UK monetary base (narrow money / M0) in £mn, year-end. BoE-spliced series — direct monetization indicator tracking central-bank-issued money.
+    splice: "BoE-spliced monetary base / M0; components in A24 Money sheet"
+    status: available
+
+  uk_boe_balance_sheet_gdp:
+    name: Bank of England Balance Sheet (% GDP)
+    category: monetary
+    frequency: annual
+    source_sheet: "A1. Headline series"
+    source_column: "Bank of England Balance sheet"
+    source_column_units: "% of nominal GDP"
+    source_header_row: 3
+    source_units_row: 5
+    source_year_start_row: 7
+    start_year: 1701
+    end_year: 2016
+    publication_lag_days: 0
+    description: Bank of England balance sheet as % of nominal GDP. Load-bearing mode-4 indicator — the direct monetization signal used by the Phase A research note to identify QE-era parallels to the sterling-transition episode.
     status: available
 
   uk_broad_money:
@@ -161,6 +226,22 @@ uk:
     description: Short-rate proxy using Bank Rate calendar-year average. No separate long historical T-bill series in A1; Bank Rate is the BoE-provided short-rate proxy.
     status: available
 
+  uk_consols_yield:
+    name: UK Consols / Long-term Government Bond Yield
+    category: rates
+    frequency: annual
+    source_sheet: "A1. Headline series"
+    source_column: "Consols / long-term government bond yields"
+    source_column_units: "%, calendar year average"
+    source_header_row: 3
+    source_units_row: 5
+    source_year_start_row: 7
+    start_year: 1703
+    end_year: 2016
+    publication_lag_days: 0
+    description: UK Consols (perpetual annuities) yield, calendar-year average. Exposed independently from the uk_10yr_gilt splice so the pre-1930 long-rate signal can be used raw for transition-era analysis.
+    status: available
+
   # --- Financial assets ---
   uk_share_prices:
     name: UK Share Price Index
@@ -203,6 +284,38 @@ uk:
     description: Sterling/USD exchange rate (USD per GBP), calendar-year average.
     status: available
 
+  uk_usd_gbp_rate:
+    name: USD/GBP Exchange Rate
+    category: asset_price
+    frequency: annual
+    source_sheet: "A1. Headline series"
+    source_column: "$/£ exchange rate"
+    source_column_units: "Calendar year average"
+    source_header_row: 3
+    source_units_row: 5
+    source_year_start_row: 7
+    start_year: 1791
+    end_year: 2016
+    publication_lag_days: 0
+    description: USD/GBP exchange rate (USD per GBP), calendar-year average. Carried as a distinct key from uk_gbp_usd for per-use convenience per specs/data_pipeline/uk.md §"Required target-series coverage". The BoE workbook exposes only "$/£" (USD per GBP) directly; both keys point at the same source column. Inverting to GBP per USD for consumers that expect that convention belongs in a derived-indicators layer, not the registry.
+    status: available
+
+  uk_real_usd_gbp_rate:
+    name: Real USD/GBP Exchange Rate (CPI-based)
+    category: asset_price
+    frequency: annual
+    source_sheet: "A1. Headline series"
+    source_column: "Real $/£ exchange rate"
+    source_column_units: "Calendar year average, 1913=100"
+    source_header_row: 3
+    source_units_row: 5
+    source_year_start_row: 7
+    start_year: 1791
+    end_year: 2016
+    publication_lag_days: 0
+    description: Real (CPI-adjusted) USD/GBP exchange rate, 1913=100, calendar-year average. Preferred signal for transition-scale analysis — separates nominal FX moves from cross-country inflation differentials.
+    status: available
+
   # --- Real assets ---
   uk_agricultural_land:
     name: UK Agricultural Land Price
@@ -234,7 +347,72 @@ uk:
     description: UK wholesale / producer price index (2010=100) used as the commodity-price-level proxy per the spec's "UK commodity price index" target. A1 has no separate CRB-style commodities composite; WPI is the BoE-provided long series closest in intent.
     status: available
 
+  uk_house_prices:
+    name: UK House Price Index
+    category: real_asset
+    frequency: annual
+    source_sheet: "A1. Headline series"
+    source_column: "House price index"
+    source_column_units: "Calendar year average, Jan 2015 =100"
+    source_header_row: 3
+    source_units_row: 5
+    source_year_start_row: 7
+    start_year: 1845
+    end_year: 2016
+    publication_lag_days: 0
+    description: UK residential house price index (Jan 2015=100), calendar-year average. BoE-spliced long composite. Load-bearing — the Phase A research note found houses preserved real value materially better than listed equity through the sterling transition.
+    splice: "BoE-spliced composite; see A32 for underlying Samy/Knoll/Nationwide/Halifax/ONS components"
+    status: available
+
+  uk_oil_price_usd:
+    name: Oil Price in USD (per barrel)
+    category: real_asset
+    frequency: annual
+    source_sheet: "A1. Headline series"
+    source_column: "$ Oil prices"
+    source_column_units: "$ per barrel"
+    source_header_row: 3
+    source_units_row: 5
+    source_year_start_row: 7
+    start_year: 1861
+    end_year: 2016
+    publication_lag_days: 0
+    description: Oil price in USD per barrel. Source (per A47 notes) BP Statistical Review of World Energy; 1861-1944 US Average, 1945-1983 Arabian Light, 1984+ Brent dated. Isolates the 1973 / 1979 oil shocks distinct from the broader WPI.
+    status: available
+
   # --- Macro ---
+  uk_real_gdp:
+    name: UK Real GDP (level)
+    category: macro
+    frequency: annual
+    source_sheet: "A1. Headline series"
+    source_column: "Real UK GDP at market prices, geographically-consistent estimate based on post-1922 borders"
+    source_column_units: "£mn, Chained Volume measure, 2013 prices"
+    source_header_row: 3
+    source_units_row: 5
+    source_year_start_row: 7
+    start_year: 1700
+    end_year: 2016
+    publication_lag_days: 0
+    description: UK real GDP level (£mn, chained-volume, 2013 prices), geographically-consistent post-1922-border estimate. Level is the primary measurement; growth rate is exposed separately via uk_real_gdp_growth.
+    status: available
+
+  uk_nominal_gdp:
+    name: UK Nominal GDP (level)
+    category: macro
+    frequency: annual
+    source_sheet: "A1. Headline series"
+    source_column: "Nominal UK GDP at market prices"
+    source_column_units: "£mn"
+    source_header_row: 3
+    source_units_row: 5
+    source_year_start_row: 7
+    start_year: 1700
+    end_year: 2016
+    publication_lag_days: 0
+    description: UK nominal GDP at market prices (£mn), constant-border UK (GB+NI) definition. Used as the denominator for any ratio that the registry doesn't already supply pre-scaled.
+    status: available
+
   uk_real_gdp_growth:
     name: UK Real GDP Growth
     category: macro
@@ -283,6 +461,22 @@ uk:
     description: Current account balance as % of nominal GDP. GB only before 1816.
     status: available
 
+  uk_trade_deficit_gdp:
+    name: UK Trade Deficit (% GDP)
+    category: macro
+    frequency: annual
+    source_sheet: "A1. Headline series"
+    source_column: "Trade deficit"
+    source_column_units: "as a % of nominal GDP"
+    source_header_row: 3
+    source_units_row: 5
+    source_year_start_row: 7
+    start_year: 1816
+    end_year: 2016
+    publication_lag_days: 0
+    description: UK trade deficit (goods + services balance) as % of nominal GDP. Distinct from current account, which also includes primary and secondary income flows (interest / profits / transfers). BoE headline column is "Trade deficit"; positive values indicate a deficit per BoE convention — consumers should check sign with an early spot value.
+    status: available
+
   # --- Reserve status ---
   uk_sterling_reserve_share:
     name: Sterling Share of Global FX Reserves
@@ -292,3 +486,37 @@ uk:
     unavailable_reason: Sterling's share of global foreign-exchange reserves is not a BoE series. Requires IMF COFER (1999+) and academic reconstructions (Eichengreen, Chitu, Mehl) for pre-1999 coverage — out of scope for a BoE-only Phase A pipeline.
     unavailable_followup_issue: 91
     description: Sterling share of global official FX reserves — the central transition variable in the sterling→USD reserve-currency shift. Expected-unavailable per issue #91.
+
+  uk_nominal_eri:
+    name: UK Nominal Effective Exchange Rate Index
+    category: reserve_status
+    frequency: annual
+    source_sheet: "A1. Headline series"
+    source_column: "Nominal ERI"
+    source_column_units: "Calendar year average, 1913=100"
+    source_header_row: 3
+    source_units_row: 5
+    source_year_start_row: 7
+    start_year: 1870
+    end_year: 2016
+    publication_lag_days: 0
+    description: UK nominal effective exchange rate index (trade-weighted basket, 1913=100), calendar-year average. Broader reserve-currency-decline signal than GBP/USD alone; captures sterling depreciation against multiple trade partners through the reserve-currency transition.
+    splice: "BoE-spliced ERI; components in A33 Exchange rate data sheet"
+    status: available
+
+  uk_real_eri:
+    name: UK Real Effective Exchange Rate Index
+    category: reserve_status
+    frequency: annual
+    source_sheet: "A1. Headline series"
+    source_column: "Real ERI"
+    source_column_units: "Calendar year average, 1913=100"
+    source_header_row: 3
+    source_units_row: 5
+    source_year_start_row: 7
+    start_year: 1870
+    end_year: 2016
+    publication_lag_days: 0
+    description: UK real effective exchange rate index (CPI-adjusted trade-weighted basket, 1913=100), calendar-year average. Separates nominal trade-weighted depreciation from cross-country inflation differentials — preferred reserve-status signal for transition analysis.
+    splice: "BoE-spliced real ERI; components in A33 Exchange rate data sheet"
+    status: available

--- a/configs/series_uk.yaml
+++ b/configs/series_uk.yaml
@@ -268,22 +268,6 @@ uk:
     unavailable_followup_issue: 93
     description: Gold price in GBP — required for a floating-rate real-asset benchmark post-1971. Expected-unavailable per issue #93.
 
-  uk_gbp_usd:
-    name: GBP/USD Exchange Rate
-    category: asset_price
-    frequency: annual
-    source_sheet: "A1. Headline series"
-    source_column: "$/£ exchange rate"
-    source_column_units: "Calendar year average"
-    source_header_row: 3
-    source_units_row: 5
-    source_year_start_row: 7
-    start_year: 1791
-    end_year: 2016
-    publication_lag_days: 0
-    description: Sterling/USD exchange rate (USD per GBP), calendar-year average.
-    status: available
-
   uk_usd_gbp_rate:
     name: USD/GBP Exchange Rate
     category: asset_price

--- a/specs/data_pipeline/uk.md
+++ b/specs/data_pipeline/uk.md
@@ -45,6 +45,8 @@ Primary source: **Bank of England "A Millennium of Macroeconomic Data" workbook*
 
 Phase A of this pipeline targets **annual series** from the `A*` sheets. Monthly series extension is explicitly out of scope for this phase (see issue #94).
 
+**A1 "Headline series" column-identification convention.** Multiple distinct series in A1 share the same Description row (row 3) — e.g., "Bank Rate" has both end-period and year-average variants; "Real UK GDP at market prices" has both level and growth variants. The `(source_sheet, source_column)` pair MUST NOT be treated as a primary key for A1; the registry's `source_column_units` field (Units row, row 5) is required for disambiguation. The spec's schema reflects this: `source_column_units` is not optional for A1-sourced series with shared Descriptions, even though a Description-only lookup may appear to work for other sheets.
+
 ### Cache and version pinning
 
 The workbook is pre-cached at `data/raw/uk/_source/millennium_of_macro_data.xlsx`. **No network fetch at any time.** This is the hard rule — see "Error behavior" below for what happens when the cache is missing.
@@ -109,9 +111,8 @@ The list was expanded on 2026-04-15 from the original 17 required series (per #5
 **Financial assets:**
 - UK equity index (BoE consolidated long series)
 - Gold price in GBP — currently expected `status: unavailable` for post-1971 per issue #93
-- GBP/USD exchange rate (nominal, GBP per USD)
-- USD/GBP exchange rate (nominal, USD per GBP — inverse; carried for convenience, avoids per-use conversion)
-- Real GBP/USD exchange rate (CPI-adjusted; preferred signal for transition-scale analysis)
+- USD/GBP nominal exchange rate — the BoE workbook exposes USD-per-GBP natively (the "$/£" column in A1; ~$4.86 classical parity). GBP/USD is derivable as 1/x in consumer code, not registered as a separate series
+- Real USD/GBP exchange rate (CPI-adjusted; preferred signal for transition-scale analysis)
 
 **Real assets:**
 - UK land prices (agricultural)
@@ -125,7 +126,7 @@ The list was expanded on 2026-04-15 from the original 17 required series (per #5
 - Real GDP growth rate
 - Unemployment rate
 - Current account / GDP
-- Trade balance / GDP (goods+services only; distinct from current account which includes primary/secondary income)
+- Trade balance / GDP (goods+services only; distinct from current account which includes primary/secondary income). **Sign convention:** the BoE workbook's "Trade deficit" column stores deficit as positive; this differs from `uk_public_deficit_gdp` which uses negative=deficit. Downstream consumers MUST check the description field before aggregating across series.
 
 **Reserve status:**
 - Sterling share of global reserves — currently expected `status: unavailable` per issue #91

--- a/specs/data_pipeline/uk.md
+++ b/specs/data_pipeline/uk.md
@@ -83,38 +83,54 @@ uk:
 
 ### Required target-series coverage for Phase A
 
-The pipeline MUST attempt to register these series (per the #52 Phase A issue description). If the BoE workbook does not contain a series under an obvious sheet name, the series MUST be registered with `status: unavailable` and the `unavailable_followup_issue` pointing to #91, #92, #93, or a new issue — not omitted:
+The pipeline MUST attempt to register these series. If the BoE workbook does not contain a series under an obvious sheet name, the series MUST be registered with `status: unavailable` and the `unavailable_followup_issue` pointing to #91, #92, #93, or a new issue — not omitted.
+
+The list was expanded on 2026-04-15 from the original 17 required series (per #52 Phase A issue description) to the 31 series below. The expansion incorporated series discovered during the archived exploratory implementation (at `archive/uk-phase-a-no-spec-2026-04-15`) — specifically the ones relevant to the monetization-mechanism, real-asset preservation, and reserve-currency-decline signatures that the Phase A research note identified as load-bearing for the umbrella thesis. The expansion is the spec catching up to what the exploratory research should have fed in upstream; see `docs/research/uk_sterling_transition.md` (when salvaged) for the exploratory phase.
 
 **Fiscal:**
 - Government debt/GDP
 - Government deficit/GDP
-- Tax revenue/GDP
+- Government spending / GDP
+- Tax revenue / GDP
 
 **Monetary:**
 - Bank Rate (official policy rate)
-- CPI or RPI inflation
+- CPI level (price index)
+- CPI or RPI inflation (rate; derivable from level but commonly used directly)
 - Broad money aggregate (M3 or equivalent consistent long series)
+- Monetary base (narrow money; direct monetization indicator)
+- Bank of England balance sheet / GDP (direct monetization indicator — the load-bearing signal for mode-4 resolution)
 
 **Rates:**
 - 10-year gilt yield (or Consols + gilt splice with `splice` field populated)
+- Consols yield (pre-1930 long-term rate, exposed independently as well as via the gilt splice)
 - Short rate (T-bill or equivalent)
 
 **Financial assets:**
 - UK equity index (BoE consolidated long series)
 - Gold price in GBP — currently expected `status: unavailable` for post-1971 per issue #93
-- GBP/USD exchange rate
+- GBP/USD exchange rate (nominal, GBP per USD)
+- USD/GBP exchange rate (nominal, USD per GBP — inverse; carried for convenience, avoids per-use conversion)
+- Real GBP/USD exchange rate (CPI-adjusted; preferred signal for transition-scale analysis)
 
 **Real assets:**
-- UK land prices
-- UK commodity price index
+- UK land prices (agricultural)
+- UK house prices (residential; Phase A research note found houses preserved real value materially better than listed equity through the sterling transition)
+- UK commodity price index (broad / wholesale)
+- Oil price in USD (specific commodity; isolates 1973 and 1979 shocks that a broad index smooths over)
 
 **Macro:**
-- Real GDP growth
+- Nominal GDP level
+- Real GDP level
+- Real GDP growth rate
 - Unemployment rate
-- Current account / trade balance as % of GDP
+- Current account / GDP
+- Trade balance / GDP (goods+services only; distinct from current account which includes primary/secondary income)
 
 **Reserve status:**
 - Sterling share of global reserves — currently expected `status: unavailable` per issue #91
+- Nominal Effective Exchange Rate Index (ERI; trade-weighted GBP value — broader reserve-currency-decline signal than GBP/USD alone)
+- Real Effective Exchange Rate Index (ERI, CPI-adjusted)
 
 ### Invariants
 

--- a/specs/data_pipeline/uk.md
+++ b/specs/data_pipeline/uk.md
@@ -87,7 +87,7 @@ uk:
 
 The pipeline MUST attempt to register these series. If the BoE workbook does not contain a series under an obvious sheet name, the series MUST be registered with `status: unavailable` and the `unavailable_followup_issue` pointing to #91, #92, #93, or a new issue — not omitted.
 
-The list was expanded on 2026-04-15 from the original 17 required series (per #52 Phase A issue description) to the 31 series below. The expansion incorporated series discovered during the archived exploratory implementation (at `archive/uk-phase-a-no-spec-2026-04-15`) — specifically the ones relevant to the monetization-mechanism, real-asset preservation, and reserve-currency-decline signatures that the Phase A research note identified as load-bearing for the umbrella thesis. The expansion is the spec catching up to what the exploratory research should have fed in upstream; see `docs/research/uk_sterling_transition.md` (when salvaged) for the exploratory phase.
+The list was expanded on 2026-04-15 from the original 17 required series (per #52 Phase A issue description) to the 30 series below. The expansion incorporated series discovered during the archived exploratory implementation (at `archive/uk-phase-a-no-spec-2026-04-15`) — specifically the ones relevant to the monetization-mechanism, real-asset preservation, and reserve-currency-decline signatures that the Phase A research note identified as load-bearing for the umbrella thesis. The expansion is the spec catching up to what the exploratory research should have fed in upstream; see `docs/research/uk_sterling_transition.md` (when salvaged) for the exploratory phase.
 
 **Fiscal:**
 - Government debt/GDP
@@ -126,7 +126,7 @@ The list was expanded on 2026-04-15 from the original 17 required series (per #5
 - Real GDP growth rate
 - Unemployment rate
 - Current account / GDP
-- Trade balance / GDP (goods+services only; distinct from current account which includes primary/secondary income). **Sign convention:** the BoE workbook's "Trade deficit" column stores deficit as positive; this differs from `uk_public_deficit_gdp` which uses negative=deficit. Downstream consumers MUST check the description field before aggregating across series.
+- Trade balance / GDP (goods+services only; distinct from current account which includes primary/secondary income). **Sign convention:** the BoE workbook's "Trade deficit" column stores deficit as positive; this differs from `uk_public_deficit_gdp` which uses negative=deficit. Downstream consumers SHOULD check the description field before aggregating across series. (This is a documentation-level convention, not test-enforced — no pipeline check asserts that description fields correctly flag sign conventions. If the convention proves inadequate, tighten by adding a spec-anchored test that verifies description-field contents for sign-sensitive series.)
 
 **Reserve status:**
 - Sterling share of global reserves — currently expected `status: unavailable` per issue #91

--- a/tests/test_uk_data_fetcher.py
+++ b/tests/test_uk_data_fetcher.py
@@ -130,10 +130,9 @@ _REQUIRED_TARGETS = {
     "uk_10yr_gilt",
     "uk_consols_yield",
     "uk_short_rate",
-    # Financial assets (5)
+    # Financial assets (4)
     "uk_share_prices",
     "uk_gold_gbp",
-    "uk_gbp_usd",
     "uk_usd_gbp_rate",
     "uk_real_usd_gbp_rate",
     # Real assets (4)

--- a/tests/test_uk_data_fetcher.py
+++ b/tests/test_uk_data_fetcher.py
@@ -114,30 +114,44 @@ _ALLOWED_CATEGORIES = {
 }
 
 _REQUIRED_TARGETS = {
-    # Fiscal
+    # Fiscal (4)
     "uk_public_debt_gdp",
     "uk_public_deficit_gdp",
     "uk_public_receipts_gdp",
-    # Monetary
+    "uk_public_spending_gdp",
+    # Monetary (6)
     "uk_bank_rate",
+    "uk_cpi",
     "uk_cpi_inflation",
     "uk_broad_money",
-    # Rates
+    "uk_monetary_base",
+    "uk_boe_balance_sheet_gdp",
+    # Rates (3)
     "uk_10yr_gilt",
+    "uk_consols_yield",
     "uk_short_rate",
-    # Financial assets
+    # Financial assets (5)
     "uk_share_prices",
     "uk_gold_gbp",
     "uk_gbp_usd",
-    # Real assets
+    "uk_usd_gbp_rate",
+    "uk_real_usd_gbp_rate",
+    # Real assets (4)
     "uk_agricultural_land",
+    "uk_house_prices",
     "uk_commodity_index",
-    # Macro
+    "uk_oil_price_usd",
+    # Macro (6)
+    "uk_nominal_gdp",
+    "uk_real_gdp",
     "uk_real_gdp_growth",
     "uk_unemployment_rate",
     "uk_current_account_gdp",
-    # Reserve status
+    "uk_trade_deficit_gdp",
+    # Reserve status (3)
     "uk_sterling_reserve_share",
+    "uk_nominal_eri",
+    "uk_real_eri",
 }
 
 

--- a/tests/test_uk_data_fetcher.py
+++ b/tests/test_uk_data_fetcher.py
@@ -160,7 +160,7 @@ def test_registry_field_completeness():
     """specs/data_pipeline/uk.md test case 3: every available series has
     source_sheet, source_column, start_year, end_year, publication_lag_days;
     every unavailable series has unavailable_reason and unavailable_followup_issue.
-    Also enforces the §"Required target-series coverage" list (17 series) and
+    Also enforces the §"Required target-series coverage" list (30 series) and
     the category enum."""
     config = load_config()
     registry = config.get("uk", {})


### PR DESCRIPTION
## Summary

Expand the UK pipeline from 17 to 30 required series, incorporating the 14 useful series discovered during the archived exploratory implementation. Resolves spec-drift observations surfaced by the implementation agent.

Demonstrates the intended spec-first flow on a \`stable/\` branch: coordinator writes the spec update first, coding agent implements against the spec, implementation surfaces further spec observations, coordinator updates the spec, agent cleans up implementation to match.

## Commits (chronological)

1. **\`2b8691b\` Spec: expand UK pipeline required series 17 → 31** — coordinator, first commit on the branch
2. **\`d481024\` Implement per spec: add 14 UK series** — coding agent, YAML + test target update
3. **\`042c659\` Update registry field-completeness test to 31 required series** — coding agent, separating test update from YAML for clean diff
4. **\`845c00d\` Spec: address 3 observations from series-expansion implementation** — coordinator, responds to agent's report-don't-patch observations (drop misnamed \`uk_gbp_usd\`, trade-deficit sign convention, A1 primary-key limitation)
5. **\`881a15f\` Remove uk_gbp_usd from registry + test targets (per spec 845c00d)** — coding agent, implementation catches up to the clarified spec

All 5 commits carry \`Co-Authored-By: Claude\` trailers — maker-checker provenance visible from \`git log\` alone.

## Series coverage

Registry is now **28 available + 2 unavailable = 30 required series**:

- **Fiscal (4):** debt/GDP, deficit/GDP, spending/GDP, receipts/GDP
- **Monetary (6):** Bank Rate, CPI level, CPI inflation, broad money, monetary base, BoE balance sheet/GDP
- **Rates (3):** 10-year gilt, Consols yield, short rate
- **Financial assets (4):** equity index, gold GBP (unavailable, #93), USD/GBP, real USD/GBP
- **Real assets (4):** agricultural land, house prices, commodity index, oil USD
- **Macro (6):** nominal GDP, real GDP, real GDP growth, unemployment, current account/GDP, trade deficit/GDP
- **Reserve status (3):** sterling reserve share (unavailable, #91), nominal ERI, real ERI

## Three spec observations surfaced during implementation (resolved in this PR)

1. **\`uk_gbp_usd\` naming drift** (from PR #97) — stored values were USD per GBP despite the name. Dropped from spec + registry in commit \`881a15f\`; \`uk_usd_gbp_rate\` is the honest name. Zero downstream consumers (landed two commits ago); no breakage.
2. **Trade deficit sign convention** — BoE stores positive=deficit; \`uk_public_deficit_gdp\` uses negative=deficit. Spec now names the gotcha explicitly.
3. **A1 primary-key limitation** — multiple series share a Description row; \`source_column_units\` is required for disambiguation. Spec's Source section now names this convention.

## Test results

- \`pytest -m "not integration" tests/test_uk_data_fetcher.py\` — 5 passed, 2 deselected (integration). No regressions.
- Integration tests verified separately by the implementation agent — 2 passed locally with the cached workbook.

## Known nit (non-blocking)

- \`test_registry_field_completeness\` docstring still says "(17 series)" — stale since commit \`042c659\` updated \`_REQUIRED_TARGETS\` to 31 and \`881a15f\` brought it to 30. Comment-only; no behavior impact. Fix in a small follow-up if the reviewer flags.

## Governance alignment

- ✅ \`stable/\` branch (per file-type heuristic — touches \`configs/\` and \`tests/\`)
- ✅ Spec authored as first commit before any implementation
- ✅ Further spec updates (observation-follow-ups) precede the implementation commit that honors them
- ✅ Coordinator/agent split: coordinator commits (spec only); agent commits (configs/, tests/ only)
- ✅ Co-Authored-By trailers on all 5 commits

🤖 Generated with [Claude Code](https://claude.com/claude-code)