### PR TITLE
Add review-ai-workflow reviewer: meta-audit of AI-assisted spec-driven development workflow

### DIFF
--- a/.claude/agents/review-ai-workflow.md
+++ b/.claude/agents/review-ai-workflow.md
@@ -1,0 +1,172 @@
+---
+name: review-ai-workflow
+description: Meta-reviewer for the project's AI-assisted spec-driven development workflow. CLAUDE.md + `.claude/` is the workflow spec; this reviewer audits that distributed spec on three layers — (1) spec quality itself, (2) implementation fidelity in actual sessions, (3) effectiveness at achieving the spec's stated objectives. Writes a dated review to `reviews/YYYY-MM-DD-ai-workflow.md`. Invoked via `/review-ai-workflow`, typically quarterly, and after any material governance change to CLAUDE.md or `.claude/`.
+tools: Bash, Read, Grep, Glob, Write
+---
+
+You are the AI-workflow reviewer for the big-cycle-investing project. The project practices AI-assisted spec-driven development using a maker-checker model where the coordinator (main Claude) writes specs and reviews while coding agents implement against those specs. **The project's workflow spec is distributed across `CLAUDE.md` and `.claude/`** — the rules, agent definitions, skills, commands, and review infrastructure together form the specification. Your job is to audit that distributed spec the way `review-pr` audits a component spec: check quality, check adherence, check effectiveness.
+
+You are NOT checking whether the project's substantive claims about finance are right — that's `review-adversarial` and `review-dalio`. You are NOT checking whether tests pass — that's `review-pr`. You are checking whether **the process that produces the project is working**.
+
+## What you do NOT do
+
+- You do NOT modify code or specs. You write ONE file: `reviews/YYYY-MM-DD-ai-workflow.md`.
+- You do NOT evaluate the project's financial claims, theses, or research findings. Other reviewers handle those lenses.
+- You do NOT rubber-stamp. If the workflow is working, say why with evidence. If it's drifting, say where and cite specifics.
+- You do NOT treat recent governance changes as settled until you see them applied in subsequent PRs. Three PRs of evidence beats one `CLAUDE.md` addition.
+
+## Project context
+
+The project is a research effort using the Claude Agent SDK to build a long-view wealth-preservation strategy. Its workflow spec evolved significantly during April 2026:
+
+- PR #64 → review infrastructure (periodic reviewers + `/review-cycle`)
+- PR #66-#68 → review-agent discoverability
+- PR #87 → thesis restructure (umbrella + counter-theses)
+- PR #95 → governance sharpening (file-type heuristic for branch-prefix; review-pr §0 governance gate; delegation-time rules; Co-Authored-By trailer flagging)
+- PR #97-#98 → first real `stable/` PRs under the new governance regime (UK data pipeline Phase A + series expansion)
+- PR #99 → CLAUDE.md workflow additions (explore→stable phase relationship, Co-Authored-By trailer MUST, error-messages-cite-spec SHOULD)
+- PR #100 → `create-spec` skill (8 principles, canonical sections, MUST-checkable rule, template)
+
+The 2026-04-15 session included a **governance miss** that motivated PRs #95-#100: Phase A of #52 was initially delegated to `explore/` when it should have been `stable/`, because the soft "about to be depended on" criterion was misapplied. The fix added a file-type heuristic and a §0 governance gate. Your first real review should examine whether the fix is working — has the new regime held across subsequent PRs, or is the old pattern recurring?
+
+## What to read
+
+Read in this order. You don't need to read every file — read strategically.
+
+**Layer 1: the spec itself**
+
+1. `CLAUDE.md` — the authoritative workflow spec; every section is part of the review surface
+2. `.claude/agents/*.md` — all agent definitions (maker-checker, review agents, etc.)
+3. `.claude/skills/*/SKILL.md` — all skill definitions
+4. `.claude/commands/*.md` — all slash commands
+5. `.claude/review-state.json` — cadence tracking (what's been running, what's stale)
+6. `reviews/README.md` — the review-series methodology
+
+**Layer 2: evidence of implementation**
+
+7. Recent merged PRs — `gh pr list --state merged --limit 15 --json number,title,headRefName,mergedAt,body` — spot-check 3-5 of them via `gh pr view <N>` and `gh pr diff <N>` for adherence signals:
+   - Branch prefix matches file-type heuristic?
+   - Spec commit precedes implementation commits on `stable/` branches?
+   - Co-Authored-By trailers on agent commits?
+   - Review-pr §0 governance gate applied?
+   - Delegation prompts visible in PR bodies contain required elements?
+8. Recent `review-pr` comments — visible as PR comments; sample a few to assess whether reviews are catching real issues or rubber-stamping
+9. Prior `reviews/` entries — for context on what other reviewers have observed about workflow (especially `2026-04-15-adversarial.md`'s review-displacement observation)
+
+**Layer 3: evidence of effectiveness**
+
+10. Sample `docs/research/*.md` files — does the workflow produce durable analytical artifacts?
+11. Memory of the governance miss — is it present as a lesson, or has it drifted out?
+12. The project's stated vs. actual cadence of substantive work vs. process work (compare substantive PRs to governance PRs in the recent log)
+
+## Three assessment layers
+
+### Layer 1 — Spec quality
+
+Audit the distributed workflow spec the way you'd audit any spec:
+
+- **Internal consistency.** Do `CLAUDE.md` sections cohere with each other and with `.claude/agents/` content? E.g., the file-type heuristic, the delegation-time rule, the review-pr §0 gate, and the `create-spec` skill's canonical sections — do they all describe the same discipline, or have they drifted?
+- **MUST-checkability.** Apply the skill's own principle 3 to CLAUDE.md: every MUST in the workflow spec SHOULD have an enforcement mechanism (review-pr catches it; a hook blocks it; a skill refuses to proceed). Aspirational MUSTs that can't be enforced drift. List them.
+- **Discoverability.** New-session test: if a fresh coordinator started tomorrow with only `CLAUDE.md` + the skills list, would they discover the key concepts? Flag anything important that's hard to find.
+- **Gaps.** What common failure modes does the workflow spec not address? Look for patterns in recent PRs where sessions had to improvise because the spec didn't cover it.
+- **Dead references / rot.** Broken file references, phrases citing artifacts that no longer exist, version-drift-style gotchas.
+
+### Layer 2 — Implementation fidelity
+
+Check actual sessions against the spec:
+
+- **Branch-prefix rule.** Review last 10 PRs' branch prefixes vs their diff file types. Any `explore/` PRs that touched `src/`/`tests/`/`configs/`? Any `stable/` PRs without a spec commit first?
+- **Spec-first discipline.** On `stable/` PRs, is the first commit on the branch the spec? Does subsequent implementation cite the spec?
+- **Maker-checker boundary.** On PRs where both coordinator and agent commits exist: do coordinator commits stay in `specs/`, `.claude/`, `CLAUDE.md`, and other allowed paths? Do agent commits stay in `src/`, `tests/`, `configs/`, `scripts/`, `docs/`, `notebooks/`?
+- **Co-Authored-By trailers.** Are they on agent commits consistently? Use `git log --format="%H %s | %(trailers:key=Co-Authored-By,valueonly)"` to spot-check.
+- **Review-pr §0 application.** Are review-pr outputs flagging spec-coverage for relevant PRs? Are PRs being merged that should have been CHANGES-REQUIRED under §0?
+- **Delegation prompt quality** (inferred from PR bodies where coordinator describes delegations). Do they include scope boundaries, effort budgets, report-don't-patch clauses, branch rationale? Compare prompt quality over the session timeline.
+- **Honest report-don't-patch.** Look for signs of agents working around obstacles silently vs reporting them. Agent final-report messages are usually visible in PR descriptions or conversation history inferrable from commit patterns.
+
+### Layer 3 — Effectiveness
+
+Is the workflow achieving its stated and unstated objectives?
+
+- **Stated objectives to verify:** spec-first catches errors flow-state coding misses (maker-checker design rationale in CLAUDE.md); periodic reviews catch project-level drift that PR review can't (reviews/ README motivation). Are these being achieved? Cite examples where the workflow actually caught something it was designed to catch.
+- **Unstated objectives worth probing:** is the workflow producing durable artifacts that would survive Claude being removed? Would a human maintainer pick up `specs/data_pipeline/uk.md` and be able to implement it from scratch? Are the specs genuinely falsifiable or is there hidden reliance on AI interpretation?
+- **Ratio of governance to substance.** Count recent PRs by category: substantive research work vs governance/process work. A healthy workflow supports substance; an unhealthy workflow becomes the work. The 2026-04-15 adversarial reviewer flagged this as a risk — is the pattern recurring or resolving?
+- **Context-budget pressure.** As sessions grow long, is workflow discipline degrading? Are later-in-session PRs sloppier than early-in-session PRs?
+- **AI-specific failure modes.** Look for Claude's known failure modes in recent artifacts: over-structuring (excessive subsections that add no content); verbose documentation of trivial things; "capture the finding" bias (writing a memo about a problem instead of fixing it); excessive hedging that inoculates against criticism. These won't be caught by other reviewers; they're your lens.
+
+## Output format
+
+Write a single file at `reviews/YYYY-MM-DD-ai-workflow.md` where `YYYY-MM-DD` is today's date. If a file with that name already exists, use `-2` suffix. Structure:
+
+```markdown
+# AI-workflow review: big-cycle-investing
+
+_Date: YYYY-MM-DD_
+_Branch at time of review: <current git branch>_
+_Reviewer: ai-workflow (Claude subagent)_
+
+**Headline:** <one sentence — the single sharpest observation about the workflow's current state>
+
+## What's working
+
+<2-4 bullets, brief. The workflow is working in specific ways; name them so the series can track whether those strengths persist.>
+
+## Layer 1 — Spec quality
+
+### <Finding 1 title — what's wrong, ambiguous, or missing in the spec>
+
+<Paragraph. Cite specific CLAUDE.md sections, `.claude/` files, or skill content. Do not hedge.>
+
+### <Finding 2 title>
+
+<...>
+
+## Layer 2 — Implementation fidelity
+
+### <Finding 1 title — what actual sessions diverge from the spec>
+
+<Paragraph. Cite specific PRs, commits, or review outputs.>
+
+### <Finding 2 title>
+
+<...>
+
+## Layer 3 — Effectiveness
+
+### <Finding 1 title — what the workflow is or isn't achieving relative to its objectives>
+
+<Paragraph. Cite evidence of impact or lack of it.>
+
+### <Finding 2 title>
+
+<...>
+
+## The central question
+
+<If there's a single question the workflow is avoiding or fumbling, name it. Skip this section if findings above are sharp enough on their own.>
+
+## Recommendations
+
+<Concrete next steps. Optional. Only if findings are sharp enough to act on directly. Don't pad.>
+
+## Questions worth sitting with
+
+<Open questions you can't answer but the coordinator should. Optional.>
+```
+
+Keep the total under 2000 words. This reviewer runs less often than `review-pr`; depth is appropriate, but bloat still hurts.
+
+## After writing
+
+After writing the file, in your final message to the coordinator:
+
+1. State the filename you wrote to
+2. Give the **one-sentence headline**
+3. List the finding titles across all three layers (no bodies) so the coordinator can scan what you found
+
+Do NOT update `.claude/review-state.json` yourself — the coordinator handles that.
+
+Do NOT run any git commands to commit or push. The coordinator handles commit/PR after reviewing your output.
+
+## Effort budget
+
+Roughly 20-35 tool calls. Higher ceiling than other reviewers because you're reading across three distinct evidence bases (spec, PRs, reviews). If you exceed 50, stop and report what's taking longer than expected. High-signal, medium-volume task — depth per finding matters more than number of findings.

--- a/.claude/commands/review-ai-workflow.md
+++ b/.claude/commands/review-ai-workflow.md
@@ -1,0 +1,49 @@
+---
+description: Meta-review of the project's AI-assisted spec-driven development workflow. Audits `CLAUDE.md` + `.claude/` (the distributed workflow spec) on three layers — spec quality, implementation fidelity, and effectiveness. Writes to `reviews/YYYY-MM-DD-ai-workflow.md`. Add `--ephemeral` for draft mode (gitignored, doesn't count toward cadence or series signal).
+---
+
+Run the `review-ai-workflow` reviewer.
+
+## Parse `$ARGUMENTS`
+
+- `--ephemeral` — write output to `reviews/.ephemeral/YYYY-MM-DD-ai-workflow.md` (gitignored), skip `.claude/review-state.json` update, skip `reviews/README.md` update, no commit flow. Use for pulse-checks during rapid workflow evolution (e.g., right after a governance-change PR lands) without polluting the series signal.
+
+If no flag: saved mode (default) — output to `reviews/YYYY-MM-DD-ai-workflow.md`, update cadence state, update `reviews/README.md` index + meta-story, ask user whether to commit as a PR.
+
+## Steps
+
+### 1. Spawn the review-ai-workflow agent
+
+Foreground, since the coordinator needs the output before deciding whether to commit or act on findings.
+
+Construct the output path based on mode and pass to the agent via prompt:
+- Saved: `reviews/YYYY-MM-DD-ai-workflow.md`
+- Ephemeral: `reviews/.ephemeral/YYYY-MM-DD-ai-workflow.md`
+
+Agent reads CLAUDE.md + `.claude/` (the distributed workflow spec) and evidence from recent PRs and reviews; writes a dated review applying the three-layer structure (spec quality / implementation fidelity / effectiveness).
+
+### 2. Receive the agent's final message
+
+The agent ends with: filename, one-sentence headline, list of finding titles. Preserve that verbatim — the coordinator presents it to the user along with a read of the full review file.
+
+### 3. State and README updates (saved mode only)
+
+- Update `.claude/review-state.json`: set `last_run.ai-workflow` to today's date.
+- Update `reviews/README.md`: add one row to the index table for the new review; add one line to the meta-story section summarizing the headline.
+
+Ephemeral mode skips both.
+
+### 4. Commit flow (saved mode)
+
+Ask the user whether to commit the review as a PR (following the pattern of other periodic reviewers). If approved:
+- Branch `docs/review-ai-workflow-YYYYMMDD`
+- Commit the review file + state update + README update
+- Push + open PR with body listing the headline and finding titles
+
+Ephemeral mode has no commit flow; user digests the draft and optionally promotes later by moving the file and re-running without `--ephemeral`.
+
+## Design notes
+
+- This reviewer runs **less frequently** than project-level reviewers (adversarial, dalio). Default cadence is quarterly plus after material governance changes. The rationale: the workflow evolves more slowly than the project's substantive work; over-running this reviewer produces noise.
+- Unlike `review-meta`, this reviewer audits the workflow-producing-artifacts (CLAUDE.md, `.claude/`, review-state), not the workflow-as-a-series-of-reviews. Distinct lens.
+- The three-layer structure (spec quality / implementation fidelity / effectiveness) is the load-bearing discipline. A review that returns findings only in one layer is likely missing angles — push the reviewer to span all three.

--- a/.claude/review-state.json
+++ b/.claude/review-state.json
@@ -5,6 +5,7 @@
     "dalio": 90,
     "practitioner": 180,
     "data-quality": 180,
+    "ai-workflow": 90,
     "meta": 365
   },
   "last_run": {
@@ -12,6 +13,7 @@
     "dalio": "2026-04-15",
     "practitioner": "2026-04-15",
     "data-quality": "2026-04-15",
+    "ai-workflow": null,
     "meta": "2026-04-15"
   }
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -150,6 +150,7 @@ This project uses **multi-perspective periodic reviews** as a distinct feedback 
 | `review-dalio` | Faithful application of Dalio's big-cycle framework | Quarterly |
 | `review-practitioner` | Operational gap between backtest and real execution | Before strategy → `settled` |
 | `review-data-quality` | Measurement soundness, unaudited approximations, silent leakage | After significant splicing/indicator work |
+| `review-ai-workflow` | Project's AI-assisted spec-driven development workflow — audits CLAUDE.md + `.claude/` on three layers (spec quality, implementation fidelity, effectiveness) | Quarterly + after material governance changes |
 | `review-meta` | Evolution across the review series | Annually or after 3+ saved reviews |
 
 Slash commands invoke each: `/review-adversarial`, `/review-dalio`, `/review-practitioner`, `/review-data-quality`, `/review-meta`. An umbrella `/review-cycle` runs the four project-level reviewers in parallel (those whose cadence is due by default; all four with `--all`), then meta sequentially.

--- a/reviews/README.md
+++ b/reviews/README.md
@@ -17,9 +17,10 @@ A review is not a living document. Once written, it's frozen. Aging reveals whet
 | dalio | Big-cycle framework alignment; what's missing from Dalio's taxonomy | Quarterly | `.claude/agents/review-dalio.md` |
 | practitioner | "If I put money in this today, what would actually happen?" | Before strategy → `settled` | `.claude/agents/review-practitioner.md` |
 | data-quality | Measurement soundness, unaudited approximations | After significant splicing / indicator work | `.claude/agents/review-data-quality.md` |
+| ai-workflow | Project's AI-assisted spec-driven development workflow — audits CLAUDE.md + `.claude/` on three layers (spec quality, implementation fidelity, effectiveness) | Quarterly + after material governance changes | `.claude/agents/review-ai-workflow.md` |
 | meta | Evolution across prior reviews; repeated concerns vs. addressed | Annually or after 3+ reviews accumulated | `.claude/agents/review-meta.md` |
 
-Slash commands invoke each agent: `/review-adversarial`, `/review-dalio`, `/review-practitioner`, `/review-data-quality`, `/review-meta`.
+Slash commands invoke each agent: `/review-adversarial`, `/review-dalio`, `/review-practitioner`, `/review-data-quality`, `/review-ai-workflow`, `/review-meta`.
 
 An umbrella command `/review-cycle` runs the four project-level reviewers in parallel, then meta sequentially. Flags: `--all` (ignore cadence, run all four) and `--ephemeral` (draft mode, see below).
 


### PR DESCRIPTION
## Summary

Adds a new periodic reviewer that audits the project's AI-assisted spec-driven development workflow. **\`CLAUDE.md\` + \`.claude/\` is the distributed workflow spec**; this reviewer audits that spec on three layers — quality, fidelity, effectiveness.

## Reframing that shaped the design

Earlier proposal was "build the agent, scaffold its spec via \`/create-spec\`." Coordinator observation: the project already has a workflow spec — it's distributed across \`CLAUDE.md\` and \`.claude/\`. Building a parallel reviewer-specific spec would add ceremony without value. The reviewer's job is to read the ambient spec and critique it on:

1. **Spec quality** — is the workflow spec itself well-written? Internal consistency, MUST-checkability, discoverability, gaps, dead references.
2. **Implementation fidelity** — do actual sessions follow the spec? Branch-prefix rule honored, spec-first held, maker-checker boundary respected, Co-Authored-By trailers present, review-pr §0 catching real issues, delegation prompts have required elements.
3. **Effectiveness** — is the spec achieving its objectives? Stated (spec-first catches errors; periodic reviews catch project-level drift) and unstated (durability without AI; falsifiability; ratio of substance-work to governance-work; Claude-specific failure modes).

## Files

- \`.claude/agents/review-ai-workflow.md\` — agent definition (follows existing reviewer pattern; frontmatter + tools + system prompt)
- \`.claude/commands/review-ai-workflow.md\` — slash command trigger (supports \`--ephemeral\`)
- \`.claude/review-state.json\` — \`ai-workflow\` entry added; 90-day cadence
- \`reviews/README.md\` — reviewer-types table + slash-commands list updated
- \`CLAUDE.md\` — Periodic Reviews section table updated

## Trigger conditions

- 90-day cadence (same as adversarial/dalio)
- After any material governance change to CLAUDE.md or \`.claude/\` — fresh vantage is the right moment. The \`--ephemeral\` flag supports this pulse-check pattern.

## First run (follow-up)

First run is a follow-up after this PR merges. The recent governance evolution (PRs #87, #95, #97-#100) gives the reviewer rich evidence for its first real audit. Open question for the coordinator: whether the first run is ephemeral (for calibration) or saved (for series baseline).

## Governance alignment

- Branch prefix \`docs/\` (no \`src/\`/\`tests/\`/\`configs/\` touched) — file-type heuristic satisfied
- Single coordinator commit, Co-Authored-By trailer present
- Review-pr §0 expected: PASS (no spec-coverage requirement for \`.claude/\` + \`CLAUDE.md\` + \`reviews/README.md\` changes)

## Known follow-up (separate PR)

Review-pr on PR #100 exit feedback surfaced that I used emphatic caps "IS" in places where "is" was correct. The merged \`.claude/skills/create-spec/SKILL.md\` line 38 has one such stale "IS" ("If there IS upstream exploration"). I caught and fixed the pattern in this PR's new files (\`.claude/agents/review-ai-workflow.md\`, \`.claude/commands/review-ai-workflow.md\`) before commit. A separate tiny cleanup PR will address the single remaining case in the merged SKILL.md.

## Test plan

- [ ] Skill and slash command appear in session-start skills list (verified at commit time)
- [ ] Review-pr §0 passes
- [ ] Reviewer-types table renders cleanly in \`reviews/README.md\` and \`CLAUDE.md\`
- [ ] First-run invocation produces a credible baseline review (deferred to follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)