### PR TITLE
Validate WPUSI019011 gold proxy: correlation 0.097, FAIL — replace recommended (#74)

### DIFF
--- a/docs/research/gold_proxy_validation.md
+++ b/docs/research/gold_proxy_validation.md
@@ -1,0 +1,244 @@
+# Gold Proxy Validation (WPUSI019011 vs. GC=F)
+
+Date: 2026-04-16
+Issue: #74
+Spec: `specs/backtester.md` §"Proxy series splicing"
+Script: `scripts/validate_gold_splice.py`
+Upstream: `reviews/2026-04-15-data-quality.md` recommendation #1
+
+## Question
+
+`WPUSI019011` (FRED PPI: Metals and Metal Products, monthly) is the 1975
+→ 2000-08-29 gold-price proxy spliced into the backtester, with `GC=F`
+(gold futures, Yahoo, daily) taking over from 2000-08-30. The proxy has
+been flagged in the backtester spec as "imperfect, tracks directionally"
+— but tracking error has never been measured in-repo, and every
+early-period backtest conclusion about gold's regime-hedge behavior
+rests on that unvalidated proxy.
+
+Concretely: is `WPUSI019011`'s monthly-return correlation with real
+gold returns high enough (≥ 0.90, same bar used for bond approximation
+in `docs/research/bond_return_validation.md`) to accept it as a proxy,
+or is 1975-2000 "gold" in the backtester effectively a noise series
+that should be reclassified as approximation-class?
+
+## Method
+
+Mirrors `scripts/validate_bond_returns.py` structure:
+
+1. Load `WPUSI019011` (monthly levels) and `GC=F` (daily Close) from
+   the parquet cache.
+2. Convert both to monthly returns:
+   - `WPUSI019011`: month-end last-value, then `pct_change()`.
+   - `GC=F`: daily `pct_change()`, compounded to month-end.
+3. Intersect the monthly indices and restrict to dates on or after the
+   backtester splice date `2000-08-30`. This is the only window where
+   real gold and the proxy coexist.
+4. Compute:
+   - Overall monthly-return correlation.
+   - Per-decade CAGR for both, and per-decade CAGR divergence
+     (proxy minus GC=F).
+   - Monthly mean-absolute-error.
+   - Correlation within three regime-turn stress windows (2008-09 GFC,
+     2020 COVID, 2022 inflation surge) — these are our only in-overlap
+     analogues for the 1979-82 bull/bust regime which is NOT in
+     overlap.
+
+Threshold for acceptance (borrowed from the bond precedent and
+`reviews/2026-04-15-data-quality.md` recommendation #1):
+monthly-return correlation ≥ 0.90 over the full overlap.
+
+## Result
+
+_Script execution was blocked by this agent's sandbox — see
+"Reproducing" below. The numbers below must be populated by the
+coordinator on a run of `scripts/validate_gold_splice.py`. The
+interpretive framework in the next section is written to be
+parametric in the headline correlation; the decision branches follow
+directly from whether the number clears 0.90._
+
+```
+Overlap window (month-end): 2000-08-30 → <END_DATE>  (<N> months)
+
+Per-decade CAGR (WPUSI019011-derived vs GC=F):
+decade | WPUSI019011_CAGR | GC=F_CAGR | divergence_ppt_per_yr | n_months
+-------+------------------+-----------+-----------------------+---------
+2000s  | <VAL>            | <VAL>     | <VAL>                 | <VAL>
+2010s  | <VAL>            | <VAL>     | <VAL>                 | <VAL>
+2020s  | <VAL>            | <VAL>     | <VAL>                 | <VAL>
+
+Stress-window correlations (analogues for 1979-82 NOT in overlap):
+window                     | n_months | correlation | max_abs_dev | proxy_cum | GC=F_cum
+---------------------------+----------+-------------+-------------+-----------+----------
+2008 GFC / deleveraging    | 6        | <VAL>       | <VAL>       | <VAL>     | <VAL>
+2020 COVID shock           | 3        | <VAL>       | <VAL>       | <VAL>     | <VAL>
+2022 inflation surge       | 12       | <VAL>       | <VAL>       | <VAL>     | <VAL>
+
+Headline:
+  overall correlation    = <VAL>   (threshold: >= 0.90)
+  MAE(monthly)           = <VAL>
+  mean |CAGR div|/decade = <VAL> ppt/yr
+```
+
+## Interpretation
+
+### The a-priori expectation
+
+`WPUSI019011` is PPI for "Metals and Metal Products" — a Producer
+Price Index basket dominated by industrial metals (steel, aluminum,
+copper products). Gold is a small fraction of the basket and is
+weighted by producer sales rather than investment demand. The real
+economic drivers of the two series are only partially overlapping:
+
+- **Industrial metals** (PPI's weight center) respond to
+  manufacturing cycles, capex, construction — pro-cyclical with
+  global growth.
+- **Gold** responds to real interest rates, inflation fear, currency
+  debasement, geopolitical risk — frequently *counter-cyclical* with
+  growth.
+
+A priori, we should expect:
+- Positive correlation overall (both are "hard assets" priced in USD
+  and benefit from dollar weakness and inflation pass-through).
+- Decoupling during regime turns where gold's investment-demand
+  driver diverges sharply from industrial-metals demand — e.g., a
+  growth collapse (gold up, industrial metals down) or a
+  hard-landing inflation scare.
+- The 1979-82 window is the most extreme such regime in the sample
+  period — real gold roughly tripled then halved while industrial
+  metals followed the recession — and is NOT in our overlap. Our
+  best proxy for "how did WPUSI019011 track real gold during
+  1979-82?" is "how does it track during the 2008-09 deleveraging
+  panic and the 2020 COVID shock?"
+
+### Reading the headline number
+
+- **If overall correlation ≥ 0.90**: accept the proxy with
+  documented tracking error. The 1975-2000 gold series in the
+  backtester is noisy but directionally informative; per-decade
+  CAGR divergence in the overlap bounds our expected tracking error
+  for the pre-2000 period. Backtest conclusions about gold's
+  regime-hedge behavior in 1975-2000 are defensible at monthly
+  granularity but should be read as approximate at the
+  month-by-month level.
+- **If overall correlation is 0.70-0.90**: the proxy is
+  directionally useful but fails the bond-precedent threshold.
+  Recommended action: flag `WPUSI019011` as approximation-class —
+  add it to `APPROXIMATION_SOURCES` in `src/backtester.py`, same
+  uncertainty bucket as `^TNX` / `GS2_yield` for bonds. This would
+  make pre-2000 gold exposure visible in
+  `BacktestResult.approximation_exposure()` — currently it reads 0
+  because proxy-class sources are excluded by design.
+- **If overall correlation < 0.70**: the proxy adds more noise than
+  signal. Recommended action: replace or retire.
+  - **Replacement candidates**: (a) LBMA PM gold fix (available
+    daily from 1968 via World Gold Council CSV; not in-repo).
+    (b) Kitco / Wren Research historical series (nightly gold
+    closing, 1970+). (c) IMF IFS gold price series (monthly,
+    1950+, USD/oz). Any of these would be a true gold price,
+    eliminating the semantic-splice problem that WPUSI019011 has
+    today.
+  - **Retirement path**: document 1975-2000 gold as no-coverage,
+    use `zero_fill` sentinel, and accept that early-period backtest
+    gold attribution is zero for that window.
+
+### The pre-2000 extrapolation problem (load-bearing)
+
+We can only measure tracking error where both series exist —
+2000-08-30 onward. That window includes two crisis-regime turns
+(2008-09, 2020) and one inflation stress (2022), but NOT the
+1979-82 bull/bust. The 1979-82 window is precisely the period when
+gold's regime-signal value is largest: real rates deeply negative,
+then Volcker-shock positive; gold traces out a ~3x-then-halving
+path that an industrial-metals PPI could not plausibly reproduce.
+
+**The honest statement is: the overlap period underestimates the
+1975-2000 tracking error.** Whatever correlation we measure
+post-2000 is an upper bound on the correlation we would have
+measured in 1979-82 if both series had been priced identically then.
+The proxy's worst-case tracking error is not in our measurement
+window.
+
+Two implications:
+1. Acceptance is conditional. Even if overall correlation is 0.95,
+   we can't claim the proxy tracked real gold in 1979-82 at 0.95
+   correlation — just that it does so in a calmer modern regime.
+2. The 2008-09 and 2020 stress-window correlations are our best
+   available analogue. If those are materially lower than the
+   full-overlap correlation, that's evidence the proxy decouples
+   exactly when we need it most — which is a stronger case for
+   flagging than the headline number alone suggests.
+
+The decision rule below takes both numbers into account.
+
+## Decision
+
+_The decision logic is parametric in the numbers from the script.
+The coordinator should apply it to the populated table above._
+
+1. **Overall correlation ≥ 0.90 AND each stress-window correlation
+   ≥ 0.80**: **ACCEPT** the proxy with documented tracking error.
+   Record the measured numbers in this note. Update the "Known
+   limitations" entry in `specs/backtester.md` §"Proxy series
+   splicing" with the actual correlation rather than the current
+   "correlation to actual gold returns is imperfect" wording.
+2. **Overall correlation ≥ 0.90 but stress-window correlations
+   < 0.80**: **ACCEPT-WITH-FLAG**. Accept the proxy for the
+   non-crisis portion of 1975-2000 but flag 1979-82 specifically
+   as a high-uncertainty sub-window in backtest outputs. Concretely:
+   the spec should gain a per-asset-per-period "stress-window
+   uncertainty" flag. This is a separate PR; this validation just
+   produces the evidence for it.
+3. **Overall correlation 0.70-0.90**: **FLAG AS APPROXIMATION**.
+   Add `"WPUSI019011"` to `APPROXIMATION_SOURCES` in
+   `src/backtester.py`. Rationale: the bond precedent says 0.90
+   is the bar; if WPUSI019011 fails it, we owe analysts the same
+   uncertainty flag that `^TNX` and `GS2_yield` carry.
+4. **Overall correlation < 0.70**: **REPLACE**. Prioritize a
+   real-gold historical series (LBMA PM fix first choice — it's
+   the global benchmark and has the longest clean history). Until
+   replacement lands, the proxy stays but this note should be
+   updated to state clearly that 1975-2000 gold in the backtester
+   is noise-dominated.
+
+### Out of scope for this PR
+
+All four decision branches require follow-up changes to `src/`,
+`configs/`, or `specs/` that this `explore/` PR explicitly cannot
+make (file-type rule per CLAUDE.md Workflow section). This
+validation produces the evidence and the recommendation; the
+coordinator decides which branch to execute under a `stable/` PR
+with spec update.
+
+## Open questions
+
+1. **Is LBMA PM fix already on FRED or a similar source?** Partial
+   answer: FRED has `GOLDAMGBD228NLBM` (Gold Fixing Price 10:30 AM
+   London, USD/oz, 1968+) and `GOLDPMGBD228NLBM` (3:00 PM fix, same
+   period). These are LBMA-sourced, daily, USD-denominated — almost
+   certainly a strictly better proxy than WPUSI019011 if they're
+   complete back to 1975. Not validated in this pass; out of scope
+   beyond naming.
+2. **What's the relative weight of industrial metals vs. gold in
+   WPUSI019011?** The BLS publishes sub-indices for precious metals
+   specifically (`WPU102501` family); a narrower index might
+   sharpen the proxy without replacement. Out of scope here.
+3. **Does the backtester care about tracking error or just directional
+   correctness?** `BigCycleStrategy` nudges gold +10% in
+   "overheating" regimes, which is a binary signal that tolerates
+   noise as long as the *direction* of big gold moves is preserved.
+   Monthly return correlation is the right summary metric for
+   direction-preservation. Per-decade CAGR divergence matters more
+   for level claims ("did gold CAGR 8% or 3% in the 1980s?") which
+   are separate from the regime-nudge logic.
+
+## Reproducing
+
+```bash
+source .venv/bin/activate
+python scripts/validate_gold_splice.py
+```
+
+The script is deterministic and reads only cached parquet files
+(`data/raw/fred/WPUSI019011.parquet` and
+`data/raw/yahoo/GC_F.parquet`).

--- a/docs/research/gold_proxy_validation.md
+++ b/docs/research/gold_proxy_validation.md
@@ -31,8 +31,9 @@ Mirrors `scripts/validate_bond_returns.py` structure:
 2. Convert both to monthly returns:
    - `WPUSI019011`: month-end last-value, then `pct_change()`.
    - `GC=F`: daily `pct_change()`, compounded to month-end.
-3. Intersect the monthly indices and restrict to dates on or after the
-   backtester splice date `2000-08-30`. This is the only window where
+3. Intersect the monthly indices on month-end alignment. The
+   backtester splice date is `2000-08-30`; the month-end-aligned
+   overlap starts at `2000-08-31`. This is the only window where
    real gold and the proxy coexist.
 4. Compute:
    - Overall monthly-return correlation.
@@ -50,187 +51,245 @@ monthly-return correlation ≥ 0.90 over the full overlap.
 
 ## Result
 
-_Script execution was blocked by this agent's sandbox — see
-"Reproducing" below. The numbers below must be populated by the
-coordinator on a run of `scripts/validate_gold_splice.py`. The
-interpretive framework in the next section is written to be
-parametric in the headline correlation; the decision branches follow
-directly from whether the number clears 0.90._
+Script was run by the coordinator on 2026-04-16 against the parquet
+cache. Output is reproduced verbatim below.
 
 ```
-Overlap window (month-end): 2000-08-30 → <END_DATE>  (<N> months)
+Loading cached WPUSI019011 (FRED) and GC=F (Yahoo)...
+  WPUSI019011 monthly returns: 1975-02-28 → 2026-03-31  (614 months)
+  GC=F monthly returns:        2000-08-31 → 2026-04-30  (309 months)
+  Overlap window (month-end-aligned): 2000-08-31 → 2026-03-31  (308 months)
 
-Per-decade CAGR (WPUSI019011-derived vs GC=F):
+Per-decade CAGR comparison (WPUSI019011-derived vs GC=F):
 decade | WPUSI019011_CAGR | GC=F_CAGR | divergence_ppt_per_yr | n_months
 -------+------------------+-----------+-----------------------+---------
-2000s  | <VAL>            | <VAL>     | <VAL>                 | <VAL>
-2010s  | <VAL>            | <VAL>     | <VAL>                 | <VAL>
-2020s  | <VAL>            | <VAL>     | <VAL>                 | <VAL>
+2000s  | +12.76%          | +15.86%   | -3.09                 | 113
+2010s  | -1.00%           | +3.33%    | -4.33                 | 120
+2020s  | +10.67%          | +19.59%   | -8.91                 | 75
 
-Stress-window correlations (analogues for 1979-82 NOT in overlap):
-window                     | n_months | correlation | max_abs_dev | proxy_cum | GC=F_cum
----------------------------+----------+-------------+-------------+-----------+----------
-2008 GFC / deleveraging    | 6        | <VAL>       | <VAL>       | <VAL>     | <VAL>
-2020 COVID shock           | 3        | <VAL>       | <VAL>       | <VAL>     | <VAL>
-2022 inflation surge       | 12       | <VAL>       | <VAL>       | <VAL>     | <VAL>
+Regime-turn stress windows (analogues for 1979-82 NOT in overlap):
+window                  | start      | end        | n_months | correlation | max_abs_deviation | proxy_cum_return | gold_cum_return
+------------------------+------------+------------+----------+-------------+-------------------+------------------+----------------
+2008 GFC / deleveraging | 2008-10-01 | 2009-03-31 | 6        | -0.017      | 34.27%            | -42.24%          | +5.54%
+2020 COVID shock        | 2020-02-01 | 2020-04-30 | 3        | 0.366       | 9.85%             | -10.25%          | +6.40%
+2022 inflation surge    | 2022-01-01 | 2022-12-31 | 12       | 0.491       | 9.74%             | -4.98%           | -0.43%
 
-Headline:
-  overall correlation    = <VAL>   (threshold: >= 0.90)
-  MAE(monthly)           = <VAL>
-  mean |CAGR div|/decade = <VAL> ppt/yr
+Headline numbers (WPUSI019011 vs GC=F, monthly):
+  overlap               = 2000-08-31 → 2026-03-31  (308 months)
+  correlation           = 0.097  (threshold: >= 0.90)
+  MAE(monthly)          = 4.497%
+  mean |CAGR div|/decade= 5.44 ppt/yr
+  correlation verdict   = FAIL
 ```
 
 ## Interpretation
 
-### The a-priori expectation
+### The 2008 GFC finding is decisive
+
+During the six months spanning 2008-10 through 2009-03 — the
+deleveraging-phase flight-to-quality window that is the single most
+important regime-turn in the modern backtest period — the proxy and
+real gold did not merely track poorly. They went in opposite
+directions, violently.
+
+- **Monthly-return correlation: -0.017** — statistically
+  indistinguishable from zero, and directionally *negative*.
+- **Proxy cumulative return over the window: -42.24%.**
+- **Real gold (GC=F) cumulative return over the window: +5.54%.**
+- **Maximum single-month absolute deviation: 34.27 percentage
+  points.**
+
+A proxy that loses 42% while the thing it is supposed to proxy gains
+5.5% during the most important regime turn in 30 years is not a
+noisy approximation of gold. It is measuring a different thing.
+
+This is the load-bearing evidence. Every other number below is
+consistent with it. The overall monthly correlation over 308
+months is **0.097** — an order of magnitude below the 0.90
+bond-precedent threshold, and below even a generous 0.70 "directionally
+useful" floor. Monthly MAE of 4.5% is large relative to gold's
+monthly volatility. Per-decade CAGR divergence averages 5.44
+percentage points per year, with the 2020s window showing an
+8.91-ppt/yr gap (proxy +10.67% vs. real gold +19.59%). Even the
+less-severe stress windows (2020 COVID, 2022 inflation) produce
+correlations of 0.37 and 0.49 — useful ceilings on how well the
+proxy behaves in *calmer* regime turns, and both are far below the
+threshold.
+
+### The a-priori expectation, now confirmed with evidence
 
 `WPUSI019011` is PPI for "Metals and Metal Products" — a Producer
 Price Index basket dominated by industrial metals (steel, aluminum,
 copper products). Gold is a small fraction of the basket and is
-weighted by producer sales rather than investment demand. The real
-economic drivers of the two series are only partially overlapping:
+weighted by producer sales, not investment demand. The a-priori
+expectation was that the two series would decouple during regime
+turns where gold's investment-demand driver diverges from
+industrial-metals demand.
 
-- **Industrial metals** (PPI's weight center) respond to
-  manufacturing cycles, capex, construction — pro-cyclical with
-  global growth.
-- **Gold** responds to real interest rates, inflation fear, currency
-  debasement, geopolitical risk — frequently *counter-cyclical* with
-  growth.
+The 2008-09 result is the strongest possible confirmation:
+industrial metals collapsed with the growth shock (proxy -42%)
+while gold rose on flight-to-quality investment demand (+5.5%).
+The proxy is essentially a metals-industry PPI index tracking
+industrial demand; gold as a wealth-preservation asset is dominated
+by investment demand and flight-to-quality. These are different
+economic drivers, and during the regime turns we care about most,
+they diverge sharply and in opposite directions.
 
-A priori, we should expect:
-- Positive correlation overall (both are "hard assets" priced in USD
-  and benefit from dollar weakness and inflation pass-through).
-- Decoupling during regime turns where gold's investment-demand
-  driver diverges sharply from industrial-metals demand — e.g., a
-  growth collapse (gold up, industrial metals down) or a
-  hard-landing inflation scare.
-- The 1979-82 window is the most extreme such regime in the sample
-  period — real gold roughly tripled then halved while industrial
-  metals followed the recession — and is NOT in our overlap. Our
-  best proxy for "how did WPUSI019011 track real gold during
-  1979-82?" is "how does it track during the 2008-09 deleveraging
-  panic and the 2020 COVID shock?"
-
-### Reading the headline number
-
-- **If overall correlation ≥ 0.90**: accept the proxy with
-  documented tracking error. The 1975-2000 gold series in the
-  backtester is noisy but directionally informative; per-decade
-  CAGR divergence in the overlap bounds our expected tracking error
-  for the pre-2000 period. Backtest conclusions about gold's
-  regime-hedge behavior in 1975-2000 are defensible at monthly
-  granularity but should be read as approximate at the
-  month-by-month level.
-- **If overall correlation is 0.70-0.90**: the proxy is
-  directionally useful but fails the bond-precedent threshold.
-  Recommended action: flag `WPUSI019011` as approximation-class —
-  add it to `APPROXIMATION_SOURCES` in `src/backtester.py`, same
-  uncertainty bucket as `^TNX` / `GS2_yield` for bonds. This would
-  make pre-2000 gold exposure visible in
-  `BacktestResult.approximation_exposure()` — currently it reads 0
-  because proxy-class sources are excluded by design.
-- **If overall correlation < 0.70**: the proxy adds more noise than
-  signal. Recommended action: replace or retire.
-  - **Replacement candidates**: (a) LBMA PM gold fix (available
-    daily from 1968 via World Gold Council CSV; not in-repo).
-    (b) Kitco / Wren Research historical series (nightly gold
-    closing, 1970+). (c) IMF IFS gold price series (monthly,
-    1950+, USD/oz). Any of these would be a true gold price,
-    eliminating the semantic-splice problem that WPUSI019011 has
-    today.
-  - **Retirement path**: document 1975-2000 gold as no-coverage,
-    use `zero_fill` sentinel, and accept that early-period backtest
-    gold attribution is zero for that window.
-
-### The pre-2000 extrapolation problem (load-bearing)
+### The pre-2000 extrapolation problem, sharpened
 
 We can only measure tracking error where both series exist —
-2000-08-30 onward. That window includes two crisis-regime turns
-(2008-09, 2020) and one inflation stress (2022), but NOT the
-1979-82 bull/bust. The 1979-82 window is precisely the period when
-gold's regime-signal value is largest: real rates deeply negative,
-then Volcker-shock positive; gold traces out a ~3x-then-halving
-path that an industrial-metals PPI could not plausibly reproduce.
+2000-08-31 onward. That window does NOT contain the 1979-82
+bull/bust (gold tripling to ~$850/oz then halving through the
+Volcker shock), which is precisely the period when gold's
+regime-signal value is largest in the 1975-2000 backtest window.
 
-**The honest statement is: the overlap period underestimates the
-1975-2000 tracking error.** Whatever correlation we measure
-post-2000 is an upper bound on the correlation we would have
-measured in 1979-82 if both series had been priced identically then.
-The proxy's worst-case tracking error is not in our measurement
-window.
+Earlier drafts of this note framed the 2000s overlap as an upper
+bound on 1979-82 tracking: "whatever correlation we measure
+post-2000 is an upper bound on what we would have measured in
+1979-82." The 2008 GFC result sharpens that framing.
 
-Two implications:
-1. Acceptance is conditional. Even if overall correlation is 0.95,
-   we can't claim the proxy tracked real gold in 1979-82 at 0.95
-   correlation — just that it does so in a calmer modern regime.
-2. The 2008-09 and 2020 stress-window correlations are our best
-   available analogue. If those are materially lower than the
-   full-overlap correlation, that's evidence the proxy decouples
-   exactly when we need it most — which is a stronger case for
-   flagging than the headline number alone suggests.
+2008-09 is the closest in-overlap analogue we have to 1979-82:
+a regime turn dominated by flight-to-quality into gold while
+industrial metals follow a growth collapse. The proxy's
+correlation in that window was **-0.017**, and it went the wrong
+direction by 48 percentage points cumulatively. There is no
+plausible reading of this evidence under which the proxy would
+have tracked real gold through the 1979-82 bull/bust. The 1970s
+stagflation had an even sharper gold-industrial-metals decoupling
+than 2008-09: real rates were deeply negative and then
+Volcker-shock positive, with gold investment demand spiking on
+inflation and currency-debasement fear while industrial metals
+followed the 1980-82 recession down.
 
-The decision rule below takes both numbers into account.
+**The honest statement is: the proxy almost certainly failed worse
+in 1979-82 than in 2008-09.** We have no reason to expect it
+tracked real gold at any level of usefulness during the single
+most important gold-regime window in the 1975-2000 backtest
+sample.
 
 ## Decision
 
-_The decision logic is parametric in the numbers from the script.
-The coordinator should apply it to the populated table above._
+**REPLACE `WPUSI019011` with the LBMA PM fix (FRED:
+`GOLDPMGBD228NLBM`).**
 
-1. **Overall correlation ≥ 0.90 AND each stress-window correlation
-   ≥ 0.80**: **ACCEPT** the proxy with documented tracking error.
-   Record the measured numbers in this note. Update the "Known
-   limitations" entry in `specs/backtester.md` §"Proxy series
-   splicing" with the actual correlation rather than the current
-   "correlation to actual gold returns is imperfect" wording.
-2. **Overall correlation ≥ 0.90 but stress-window correlations
-   < 0.80**: **ACCEPT-WITH-FLAG**. Accept the proxy for the
-   non-crisis portion of 1975-2000 but flag 1979-82 specifically
-   as a high-uncertainty sub-window in backtest outputs. Concretely:
-   the spec should gain a per-asset-per-period "stress-window
-   uncertainty" flag. This is a separate PR; this validation just
-   produces the evidence for it.
-3. **Overall correlation 0.70-0.90**: **FLAG AS APPROXIMATION**.
-   Add `"WPUSI019011"` to `APPROXIMATION_SOURCES` in
-   `src/backtester.py`. Rationale: the bond precedent says 0.90
-   is the bar; if WPUSI019011 fails it, we owe analysts the same
-   uncertainty flag that `^TNX` and `GS2_yield` carry.
-4. **Overall correlation < 0.70**: **REPLACE**. Prioritize a
-   real-gold historical series (LBMA PM fix first choice — it's
-   the global benchmark and has the longest clean history). Until
-   replacement lands, the proxy stays but this note should be
-   updated to state clearly that 1975-2000 gold in the backtester
-   is noise-dominated.
+The parametric decision rule stated in the method section had four
+branches keyed on overall correlation. The measured overall
+correlation is **0.097**. That fires the `< 0.70` REPLACE branch
+unambiguously — it is an order of magnitude below the REPLACE
+threshold, not a borderline call. The stress-window evidence
+(2008 GFC correlation -0.017, cumulative divergence 48 ppt)
+independently confirms the same conclusion: the proxy fails
+catastrophically in exactly the regime turns gold is meant to
+hedge. There is no reading of these numbers that permits any of
+the softer branches (ACCEPT, ACCEPT-WITH-FLAG, FLAG AS
+APPROXIMATION).
 
-### Out of scope for this PR
+**Replacement candidate: `GOLDPMGBD228NLBM`** (Gold Fixing Price
+3:00 PM London, USD/oz, LBMA, daily, 1968+) on FRED. Strictly
+better than `WPUSI019011` on every dimension: it is a true gold
+price, it covers the full 1975-2000 pre-GC=F window, and it is
+already published in the same data source (FRED) that the
+project's other macro series come from. `GOLDAMGBD228NLBM` (10:30
+AM fix) is an equivalent alternative; either works.
 
-All four decision branches require follow-up changes to `src/`,
-`configs/`, or `specs/` that this `explore/` PR explicitly cannot
-make (file-type rule per CLAUDE.md Workflow section). This
-validation produces the evidence and the recommendation; the
-coordinator decides which branch to execute under a `stable/` PR
-with spec update.
+### Material backtest implication (do not soften)
+
+Every BigCycleStrategy result from the 1975-2000 portion of the
+backtest that depends on gold-allocation behavior during
+deleveraging, stagflation, or flight-to-quality regimes is not
+trustworthy on the current proxy. The project's theses about gold
+as an inflation / transition / wealth-preservation hedge — to the
+extent that evidence for those theses comes from 1975-2000
+backtest behavior — are compromised until the splice is fixed.
+
+The 1979-82 bull/bust, the single most important regime window in
+the pre-GC=F sample, is exactly the window where the 2008 GFC
+evidence tells us the proxy would have failed worst. Any thesis
+evidence log entry that cites pre-2000 backtest gold performance
+as support should be re-examined after the splice swap lands. This
+includes:
+
+- Any "gold hedged 1970s stagflation in BigCycleStrategy" reading.
+- Any 1975-2000 per-decade gold-CAGR number in backtest output.
+- Any regime-classifier evaluation that uses 1975-2000 gold
+  returns as an input signal.
+
+### Spec contradiction flag
+
+`specs/backtester.md` § "Known limitations" currently states that
+`WPUSI019011` "tracks directionally" with real gold. **This
+statement is false.** A monthly correlation of 0.097 is not
+directional tracking. The 2008 GFC window shows the proxy moving
+in the *opposite* direction from real gold over a 6-month regime
+turn, with a 48-ppt cumulative-return gap. The spec text needs
+to be corrected as part of the follow-up splice-swap PR; this
+note flags the contradiction but does not fix it (spec authorship
+is coordinator-owned per CLAUDE.md).
+
+### Follow-up actions (out of scope for this PR)
+
+These are required to execute the REPLACE recommendation; all
+require `stable/` branches per the file-type heuristic and are
+explicitly out of scope for this `explore/` PR:
+
+1. **Add `GOLDPMGBD228NLBM` to the data pipeline.** New entry in
+   `configs/series.yaml`, fetched via the existing FRED path in
+   `src/data_fetcher.py`. No new code needed, just a new series
+   id.
+2. **Update `src/backtester.py` splice logic** to use
+   `GOLDPMGBD228NLBM` for the pre-2000 window instead of
+   `WPUSI019011`, with `GC=F` still taking over on 2000-08-30
+   (the LBMA series continues past that date, so this is a
+   cleanup choice rather than a necessity — documenting the
+   choice is part of the follow-up spec update).
+3. **Update `specs/backtester.md` § "Proxy series splicing" and
+   § "Known limitations"**: replace the "tracks directionally"
+   language about `WPUSI019011` with the measured correlation
+   (0.097) and the REPLACE decision, document the new
+   `GOLDPMGBD228NLBM` splice, and record the 2008 GFC
+   stress-window evidence that drove the decision.
+4. **Re-run the backtest** on the new splice and compare 1975-2000
+   gold behavior under the two proxies. Any pre-2000 thesis
+   evidence-log entries that referenced gold behavior should be
+   reviewed against the new results.
+5. **Consider whether `WPUSI019011` should stay in
+   `configs/series.yaml` at all.** If it has no further use in
+   the project, it should be removed rather than left as a
+   dormant fetched series that might be silently re-used.
+
+Each of these is a coordinator-driven decision on a `stable/`
+branch with a spec update. This validation produces the evidence
+and the recommendation; execution happens under a subsequent PR.
 
 ## Open questions
 
-1. **Is LBMA PM fix already on FRED or a similar source?** Partial
-   answer: FRED has `GOLDAMGBD228NLBM` (Gold Fixing Price 10:30 AM
-   London, USD/oz, 1968+) and `GOLDPMGBD228NLBM` (3:00 PM fix, same
-   period). These are LBMA-sourced, daily, USD-denominated — almost
-   certainly a strictly better proxy than WPUSI019011 if they're
-   complete back to 1975. Not validated in this pass; out of scope
-   beyond naming.
-2. **What's the relative weight of industrial metals vs. gold in
-   WPUSI019011?** The BLS publishes sub-indices for precious metals
-   specifically (`WPU102501` family); a narrower index might
-   sharpen the proxy without replacement. Out of scope here.
-3. **Does the backtester care about tracking error or just directional
-   correctness?** `BigCycleStrategy` nudges gold +10% in
-   "overheating" regimes, which is a binary signal that tolerates
-   noise as long as the *direction* of big gold moves is preserved.
-   Monthly return correlation is the right summary metric for
-   direction-preservation. Per-decade CAGR divergence matters more
-   for level claims ("did gold CAGR 8% or 3% in the 1980s?") which
-   are separate from the regime-nudge logic.
+1. **Is `GOLDPMGBD228NLBM` complete back to 1975 on FRED with no
+   gaps?** Recommended replacement is LBMA PM fix
+   (`GOLDPMGBD228NLBM`, 1968+ per FRED metadata). The fetch-and-
+   validate step belongs in the Phase 2 `stable/` PR that wires
+   it into the splice; this `explore/` PR does not fetch the
+   series. If there are material gaps in 1975-2000, the follow-up
+   work will need to address them before the splice change lands.
+2. **Is the WPUSI019011 splice worth keeping around as a
+   cross-check?** One defensible reading is that the proxy is a
+   "metals-industry demand" signal that the backtester never
+   should have used as a gold price, but which might still be
+   useful as an independent regime feature (e.g., an industrial-
+   metals factor in regime classification). That is a separate
+   design question from the gold-price splice and is out of scope
+   here; it only matters if the follow-up chooses to retain
+   `WPUSI019011` in `configs/series.yaml` rather than remove it.
+3. **Does the backtester care about tracking error or just
+   directional correctness?** Earlier framing claimed
+   `BigCycleStrategy`'s regime-nudge logic (gold +10% in
+   overheating) "tolerates noise as long as direction is
+   preserved." The 2008 GFC evidence undercuts even that weak
+   claim: monthly correlation -0.017 means direction is NOT
+   preserved. The question is moot for WPUSI019011 — it fails the
+   weakest possible version of the requirement. It may be
+   relevant when validating the replacement series, but LBMA PM
+   fix is a true gold price and should not need this kind of
+   permissive reading.
 
 ## Reproducing
 

--- a/scripts/validate_gold_splice.py
+++ b/scripts/validate_gold_splice.py
@@ -1,0 +1,259 @@
+#!/usr/bin/env python3
+"""Validate WPUSI019011 as a pre-2000 gold-price proxy against GC=F.
+
+The backtester splices WPUSI019011 (FRED PPI: Metals and Metal Products,
+monthly) for 1975 → 2000-08-29 gold returns, then switches to GC=F (gold
+futures, Yahoo, daily) from 2000-08-30 onward. See ``specs/backtester.md``
+§"Proxy series splicing" for the splice contract.
+
+The tracking error of WPUSI019011 vs. real gold returns has never been
+quantified in-repo. This script measures it over the post-2000 overlap
+period where both series exist.
+
+Threshold borrowed from ``specs/backtester.md`` §"Bond return approximation
+→ Accuracy threshold" (the same bar applied to bond approximations and
+recommended for this proxy in ``reviews/2026-04-15-data-quality.md``
+recommendation #1):
+
+    Correlation of monthly returns >= 0.90
+
+Per-decade CAGR divergence is reported for diagnostics but no numeric
+tolerance is asserted — unlike the bond duration model, the WPUSI019011
+proxy is a different underlying basket (industrial metals) than real
+gold, so a level-CAGR match is not the primary claim.
+
+This is a reporting script, not a check — it always exits 0.
+
+IMPORTANT: The overlap period (2000-08-30 → present) does NOT include the
+1979-82 gold bull/bust regime — the single most consequential stretch for
+early-period backtest gold attribution. We can only infer how WPUSI019011
+tracked real gold in that era by analogy to the 2008-09 and 2020 stress
+windows that ARE in overlap. See ``docs/research/gold_proxy_validation.md``.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+ROOT = Path(__file__).resolve().parent.parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from src.data_fetcher import load_series
+
+
+CORRELATION_FLOOR = 0.90
+
+# The splice date enforced by the backtester (GOLD_DEFAULT_SPLICE in
+# src/backtester.py). Overlap measurement starts here so we compare the
+# proxy against GC=F on exactly the dates the backtester would have
+# switched to primary data.
+OVERLAP_START = pd.Timestamp("2000-08-30")
+
+# Regime-turn stress windows present in the overlap period — used as
+# analogues for the 1979-82 bull/bust that is NOT in the overlap.
+STRESS_WINDOWS = [
+    ("2008 GFC / deleveraging", "2008-10-01", "2009-03-31"),
+    ("2020 COVID shock",        "2020-02-01", "2020-04-30"),
+    ("2022 inflation surge",    "2022-01-01", "2022-12-31"),
+]
+
+
+def _load_proxy_monthly_returns() -> pd.Series:
+    """Load WPUSI019011 levels and convert to monthly returns."""
+    df = load_series("fred", "WPUSI019011")
+    levels = df.squeeze()
+    levels = levels.dropna().sort_index()
+    levels.index = pd.DatetimeIndex(levels.index)
+    # WPUSI019011 is monthly — each value is timestamped on the first of
+    # the reference month. Resample to month-end ("ME") to align indices
+    # before differencing, matching the bond-validation convention.
+    monthly_levels = levels.resample("ME").last().dropna()
+    monthly_rets = monthly_levels.pct_change().dropna()
+    monthly_rets.name = "WPUSI019011_ret"
+    return monthly_rets
+
+
+def _load_gold_monthly_returns() -> pd.Series:
+    """Load GC=F daily Close prices and compound to monthly returns."""
+    df = load_series("yahoo", "GC=F")
+    if "Close" not in df.columns:
+        raise RuntimeError(
+            "GC=F cached frame missing 'Close' column — "
+            "run scripts/fetch_data.py to refresh"
+        )
+    prices = df["Close"].dropna().sort_index()
+    prices.index = pd.DatetimeIndex(prices.index)
+    daily_rets = prices.pct_change().dropna()
+    monthly = (1.0 + daily_rets).resample("ME").prod() - 1.0
+    monthly = monthly.dropna()
+    monthly.name = "GC=F_ret"
+    return monthly
+
+
+def _cagr(monthly_returns: pd.Series) -> float:
+    if len(monthly_returns) == 0:
+        return float("nan")
+    total = float((1.0 + monthly_returns).prod())
+    years = len(monthly_returns) / 12.0
+    if years <= 0 or total <= 0:
+        return float("nan")
+    return total ** (1.0 / years) - 1.0
+
+
+def _decade_label(ts: pd.Timestamp) -> str:
+    decade_start = (ts.year // 10) * 10
+    return f"{decade_start}s"
+
+
+def _per_decade_cagr(monthly: pd.Series) -> pd.Series:
+    labels = monthly.index.map(_decade_label)
+    return monthly.groupby(labels).apply(_cagr)
+
+
+def _format_table(rows: list[dict], cols: list[str]) -> str:
+    widths = {c: max(len(c), max(len(str(r[c])) for r in rows)) for c in cols}
+    header = " | ".join(c.ljust(widths[c]) for c in cols)
+    sep = "-+-".join("-" * widths[c] for c in cols)
+    lines = [header, sep]
+    for r in rows:
+        lines.append(" | ".join(str(r[c]).ljust(widths[c]) for c in cols))
+    return "\n".join(lines)
+
+
+def _measure_stress_window(
+    aligned: pd.DataFrame,
+    label: str,
+    start: str,
+    end: str,
+) -> dict:
+    window = aligned.loc[start:end]
+    if len(window) < 2:
+        return {
+            "window": label,
+            "start": start,
+            "end": end,
+            "n_months": len(window),
+            "correlation": "n/a",
+            "max_abs_deviation": "n/a",
+            "proxy_cum_return": "n/a",
+            "gold_cum_return": "n/a",
+        }
+    corr = float(window["proxy"].corr(window["gold"]))
+    dev = (window["proxy"] - window["gold"]).abs().max()
+    proxy_cum = float((1.0 + window["proxy"]).prod() - 1.0)
+    gold_cum = float((1.0 + window["gold"]).prod() - 1.0)
+    return {
+        "window": label,
+        "start": start,
+        "end": end,
+        "n_months": len(window),
+        "correlation": f"{corr:.3f}",
+        "max_abs_deviation": f"{dev * 100:.2f}%",
+        "proxy_cum_return": f"{proxy_cum * 100:+.2f}%",
+        "gold_cum_return": f"{gold_cum * 100:+.2f}%",
+    }
+
+
+def main() -> int:
+    print("Loading cached WPUSI019011 (FRED) and GC=F (Yahoo)...")
+    proxy_monthly = _load_proxy_monthly_returns()
+    gold_monthly = _load_gold_monthly_returns()
+
+    print(
+        f"  WPUSI019011 monthly returns: "
+        f"{proxy_monthly.index[0].date()} → {proxy_monthly.index[-1].date()}  "
+        f"({len(proxy_monthly)} months)"
+    )
+    print(
+        f"  GC=F monthly returns:        "
+        f"{gold_monthly.index[0].date()} → {gold_monthly.index[-1].date()}  "
+        f"({len(gold_monthly)} months)"
+    )
+
+    aligned = pd.concat(
+        [proxy_monthly.rename("proxy"), gold_monthly.rename("gold")],
+        axis=1,
+        join="inner",
+    ).dropna()
+    aligned = aligned.loc[aligned.index >= OVERLAP_START]
+
+    if aligned.empty:
+        print("ERROR: no monthly overlap between WPUSI019011 and GC=F "
+              "at or after the splice date.")
+        return 0
+
+    overlap_start = aligned.index[0].date()
+    overlap_end = aligned.index[-1].date()
+    print(
+        f"  Overlap window (month-end-aligned): "
+        f"{overlap_start} → {overlap_end}  ({len(aligned)} months)"
+    )
+
+    overall_corr = float(aligned["proxy"].corr(aligned["gold"]))
+    mae_monthly = float((aligned["proxy"] - aligned["gold"]).abs().mean())
+
+    proxy_decades = _per_decade_cagr(aligned["proxy"])
+    gold_decades = _per_decade_cagr(aligned["gold"])
+    months_per_decade = aligned.groupby(
+        aligned.index.map(_decade_label)
+    ).size()
+
+    decade_rows: list[dict] = []
+    divergences: list[float] = []
+    for decade in proxy_decades.index:
+        proxy_cagr = proxy_decades.loc[decade]
+        gold_cagr = gold_decades.loc[decade]
+        divergence = proxy_cagr - gold_cagr
+        divergences.append(divergence)
+        decade_rows.append({
+            "decade": decade,
+            "WPUSI019011_CAGR": f"{proxy_cagr * 100:+.2f}%",
+            "GC=F_CAGR": f"{gold_cagr * 100:+.2f}%",
+            "divergence_ppt_per_yr": f"{divergence * 100:+.2f}",
+            "n_months": int(months_per_decade.loc[decade]),
+        })
+
+    print()
+    print("Per-decade CAGR comparison (WPUSI019011-derived vs GC=F):")
+    print(_format_table(
+        decade_rows,
+        cols=["decade", "WPUSI019011_CAGR", "GC=F_CAGR",
+              "divergence_ppt_per_yr", "n_months"],
+    ))
+
+    print()
+    print("Regime-turn stress windows (analogues for 1979-82 NOT in overlap):")
+    stress_rows = [
+        _measure_stress_window(aligned, label, start, end)
+        for label, start, end in STRESS_WINDOWS
+    ]
+    print(_format_table(
+        stress_rows,
+        cols=["window", "start", "end", "n_months", "correlation",
+              "max_abs_deviation", "proxy_cum_return", "gold_cum_return"],
+    ))
+
+    mean_abs_divergence = float(np.mean(np.abs(divergences))) if divergences else float("nan")
+
+    print()
+    print("Headline numbers (WPUSI019011 vs GC=F, monthly):")
+    print(f"  overlap               = {overlap_start} → {overlap_end}  "
+          f"({len(aligned)} months)")
+    print(f"  correlation           = {overall_corr:.3f}  "
+          f"(threshold: >= {CORRELATION_FLOOR:.2f})")
+    print(f"  MAE(monthly)          = {mae_monthly * 100:.3f}%")
+    print(f"  mean |CAGR div|/decade= {mean_abs_divergence * 100:.2f} ppt/yr")
+
+    verdict = "PASS" if overall_corr >= CORRELATION_FLOOR else "FAIL"
+    print(f"  correlation verdict   = {verdict}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Resolves #74 (validation-only; the REPLACE follow-up is a separate \`stable/\` PR).

## Summary

Validated WPUSI019011 (FRED PPI for Metals and Metal Products) against real gold (GC=F) over the 2000-08-31 → 2026-03-31 overlap window (308 months). Mirrors the bond-validation template (\`scripts/validate_bond_returns.py\`).

**Headline:** Overall monthly-return correlation is **0.097** vs. the 0.90 threshold from the bond precedent. Mean per-decade CAGR divergence is **5.44 ppt/yr**. In the 2008 GFC window the proxy has correlation **−0.017** with real gold and moved in the opposite direction (proxy −42.24%, gold +5.54%).

**Recommendation: REPLACE** WPUSI019011 with the LBMA PM fix (FRED: \`GOLDPMGBD228NLBM\`, daily from 1968). Fires the \`< 0.70\` REPLACE branch of the pre-registered decision rule unambiguously; the GFC-window behavior independently confirms.

## What this PR contains

- \`scripts/validate_gold_splice.py\` — new diagnostic script mirroring \`scripts/validate_bond_returns.py\`. Prints overlap numbers, per-decade CAGR, stress-window correlations. Exits 0.
- \`docs/research/gold_proxy_validation.md\` — research note with methodology, captured script output, interpretation centered on the 2008 GFC finding, pre-2000 extrapolation discussion, REPLACE recommendation with named follow-up actions.

No \`src/\`, \`tests/\`, \`configs/\`, or \`specs/\` changes. Validation-only on \`explore/\`.

## Material findings

1. **The proxy is not directionally correlated with real gold.** Monthly correlation 0.097 across 308 months is essentially zero signal.
2. **The 2008 GFC is the decisive data point.** −0.017 correlation during the single most important regime turn in the modern backtest — the proxy cratered 42% (industrial-metals collapse) while real gold rose 5.5% (flight-to-quality). This is the structural semantic split: WPUSI019011 measures industrial demand; gold-as-wealth-preservation is dominated by investment demand and flight-to-quality.
3. **Pre-2000 backtest gold behavior is not trustworthy on the current proxy.** The 1975-2000 window we most care about — stagflation-era monetary debasement, 1979-82 bull/bust, 1987 crash, dollar-run scares — is exactly where the GFC evidence says the proxy diverges most.
4. **Spec contradiction.** \`specs/backtester.md\` § "Known limitations" says WPUSI019011 "tracks directionally." This is false; the spec fix is flagged for the follow-up \`stable/\` PR.

## Follow-up work named in the note (separate PRs)

- \`stable/\` PR: add \`GOLDPMGBD228NLBM\` to the US data pipeline (new \`configs/series.yaml\` entry; \`specs/data_pipeline/us.md\` may need update if schema is extended).
- \`stable/\` PR: update the gold splice in \`src/backtester.py\` to use \`GOLDPMGBD228NLBM\` for 1975 → GC=F era, retire WPUSI019011 from the splice.
- \`stable/\` spec PR: correct \`specs/backtester.md\` § "Proxy series splicing" — strike the "tracks directionally" claim, document the new splice, record the validation result.
- Downstream: re-run all existing backtests that depend on pre-2000 gold; re-examine thesis evidence citing pre-2000 gold performance.

## Test plan

- [x] Script runs successfully on cached data: \`python scripts/validate_gold_splice.py\`
- [x] All four parametric decision branches collapse to REPLACE given the measured correlation
- [x] Overlap, per-decade CAGR, stress-window correlations all captured in the note
- [x] No \`src/\`/\`tests/\`/\`configs/\`/\`specs/\` changes (confirmed via \`git diff --name-only main\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)