### PR TITLE
Bump CLAUDE.md commit-trailer example from Opus 4.6 to 4.7

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,7 +115,7 @@ you're about to stabilize, write the spec BEFORE the refactor.
   explicitly acknowledge "no upstream exploration; risk of spec drift during
   implementation is accepted" (see Workflow section's "Typical phased flow").
 - **Coding-agent commit attribution:** coding agents MUST include a
-  `Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>`
+  `Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>`
   (or equivalent current-model) trailer on every commit they produce. The
   coordinator MUST state this requirement in every delegation prompt. Rationale:
   the maker-checker model's provenance boundary (coordinator-authored specs,


### PR DESCRIPTION
## Summary

One-line update to CLAUDE.md's "Coding-agent commit attribution" rule. Claude Code 2.1.111 (2026-04-16) shipped Opus 4.7 with a new `xhigh` effort level and auto-mode for Max subscribers; this session (and recent agent commits, e.g. on PR #105) already use the 4.7 trailer, so the CLAUDE.md example was a version behind reality.

## Why this is docs/ and not a rule change

The rule text reads "or equivalent current-model" — so swapping the example doesn't alter the normative contract. Only the illustrative version bumps.

## Files

- CLAUDE.md — one line, 4.6 to 4.7

## Related

- Changelog check session (2.1.108 to 2.1.112) that surfaced this
- #108 — separate exploration issue filed to evaluate /ultrareview against our project-specific review-pr agent

🤖 Generated with [Claude Code](https://claude.com/claude-code)