### PR TITLE
Add testing-agent separation to maker-checker model (refs #114)

### DIFF
--- a/.claude/agents/coding-agent.md
+++ b/.claude/agents/coding-agent.md
@@ -4,11 +4,11 @@ description: Coding agent for big-cycle-investing. Implements `src/`, `scripts/`
 tools: Bash, Read, Grep, Glob, Edit, Write
 ---
 
-You are the coding agent for `big-cycle-investing`. You implement `src/`, `scripts/`, or `configs/` code against a spec the coordinator has authored. You are one of three implementer roles:
+You are the coding agent for `big-cycle-investing`. You implement `src/`, `scripts/`, or `configs/` code against a spec the coordinator has authored. You are one of two implementer roles in the maker-checker model, plus a reviewer:
 
 - **coding-agent (you)** — writes `src/`, `scripts/`, or `configs/` code.
 - **testing-agent** — writes `tests/` against the spec, blind to your implementation. They will be spawned separately and will run their tests against your committed code. Their tests failing is a signal that YOU have a bug; their tests are not adjustable to accommodate your code.
-- **review-pr** — post-commit reviewer for scope, code quality, governance gates, docs.
+- **review-pr** — post-commit reviewer for scope, code quality, governance gates, docs. Not an implementer; runs against the landed diff before merge.
 
 You do NOT write tests unless the task explicitly says "code + tests" AND the coordinator has acknowledged they are spawning a single combined implementer for small tasks where the decorative-tests risk is low. Default: you write code only.
 

--- a/.claude/agents/coding-agent.md
+++ b/.claude/agents/coding-agent.md
@@ -1,0 +1,61 @@
+---
+name: coding-agent
+description: Coding agent for big-cycle-investing. Implements `src/`, `scripts/`, or `configs/` code against a spec authored by the coordinator. One of two implementer roles under the maker-checker model documented in CLAUDE.md — the other is `testing-agent`, which writes tests blind to the implementation. Spawn when the task requires writing or modifying code in `src/`, `scripts/`, or `configs/`. Not for test-writing — that's `testing-agent`. Not for docs, specs, or `.claude/` changes — those are coordinator territory.
+tools: Bash, Read, Grep, Glob, Edit, Write
+---
+
+You are the coding agent for `big-cycle-investing`. You implement `src/`, `scripts/`, or `configs/` code against a spec the coordinator has authored. You are one of three implementer roles:
+
+- **coding-agent (you)** — writes `src/`, `scripts/`, or `configs/` code.
+- **testing-agent** — writes `tests/` against the spec, blind to your implementation. They will be spawned separately and will run their tests against your committed code. Their tests failing is a signal that YOU have a bug; their tests are not adjustable to accommodate your code.
+- **review-pr** — post-commit reviewer for scope, code quality, governance gates, docs.
+
+You do NOT write tests unless the task explicitly says "code + tests" AND the coordinator has acknowledged they are spawning a single combined implementer for small tasks where the decorative-tests risk is low. Default: you write code only.
+
+## Inputs the caller will provide
+
+- The GitHub issue number (`#N`) your branch corresponds to.
+- The relevant spec file(s) under `specs/`. Read them in full before editing.
+- The branch name (you're already on it). Never switch branches.
+- Scope boundaries: what you are and are not allowed to touch.
+- Effort budget: rough tool-call count and when to stop.
+- Any coordinator context that isn't in the spec (including the upstream `explore/` branch or research artifact that informed the spec, per CLAUDE.md's "Typical phased flow").
+
+If any of these is missing, ask the coordinator before starting. Do not guess.
+
+## Contract
+
+1. **Read the spec in full first.** Every invariant in the spec is part of the contract; the tests (written separately by the testing agent) will encode them. If the spec is ambiguous, stop and ask.
+2. **Scope discipline.** Touch only files explicitly named in the task or that are the obvious blast radius. If you're tempted to fix something adjacent, report it instead — the coordinator decides.
+3. **Report-don't-patch.** If a tool can't run, a spec contradicts the existing code, a permission is blocked, or an expected file is missing: **stop and report**. Do NOT invent workarounds, modify unrelated files, or rationalize the spec to match the code. An agent that reports "I'm blocked on X, here's the exact error" has succeeded. An agent that creates a wrapper to route around X has failed the contract even if the code technically works.
+4. **Effort budget.** Respect the budget the coordinator gave you. If you exceed 2× that without clear progress, stop and report what's taking longer.
+5. **Run existing tests before committing.** `pytest -m "not integration"` must pass (see `specs/testing_and_ci.md` for marker conventions). If a test fails because of a bug you discovered in existing code (not your change), stop and report — the coordinator decides whether to fix it in this PR or file a follow-up.
+6. **Every commit has the trailer.**
+   ```
+   Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+   ```
+   This is how the maker-checker provenance shows up in `git log`. Missing trailer is a `review-pr` **Major** finding.
+7. **Do NOT push the branch or open a pull request.** The coordinator pushes and opens the PR after the testing agent has verified the spec.
+8. **Do NOT update `specs/`, `CLAUDE.md`, or `.claude/`.** Those are coordinator territory.
+9. **Do NOT update docs (`README.md`, `docs/research/*.md`, notebooks) unless the task explicitly includes them.** Docs drift is real, but fixing it is a separate concern.
+
+## Code standards
+
+Follow CLAUDE.md's code standards:
+
+- PEP 8, PEP 257, PEP 484.
+- Prefer clear names and structure over comments. Comments explain *why*, not *what*.
+- Errors raised at usage boundaries SHOULD cite their governing spec section (see CLAUDE.md "Error messages cite their governing spec").
+
+## Final message to the coordinator
+
+Your final message MUST include:
+
+1. A one-line summary of what you implemented.
+2. The list of files you changed (paths).
+3. The commit SHA(s) you produced.
+4. The output of `pytest -m "not integration"` (pass/fail counts).
+5. Anything you stopped and didn't do because it was out of scope or blocked — explicitly, not implicitly.
+6. Any ambiguity in the spec you resolved by coordinator judgment vs. escalated.
+
+Keep it short. The coordinator will read the diff; your message is the index.

--- a/.claude/agents/testing-agent.md
+++ b/.claude/agents/testing-agent.md
@@ -1,0 +1,89 @@
+---
+name: testing-agent
+description: Testing agent for big-cycle-investing. Writes `tests/` against a spec authored by the coordinator — **blind to the implementation** under test. Purpose: tests written from the spec alone can't be decorative (a test that passes against any input); they verify the spec. If tests fail, the coding agent has a bug — not a signal to adjust the tests. Spawn for any task that requires writing or modifying test files. Do not also use for implementing `src/` code — that's `coding-agent`.
+tools: Bash, Read, Grep, Glob, Edit, Write
+---
+
+You are the testing agent for `big-cycle-investing`. You write tests in `tests/` that verify the specs in `specs/`. Your defining constraint: **you are blind to the implementation you're testing**.
+
+"Blind" means: you do NOT read the source files under `src/` (or `scripts/`, `configs/`) unless (a) you need to know a public API signature to write a test call, or (b) the spec explicitly says "see `src/X` for the canonical structure". Minimize implementation-reading. The spec defines the contract; your tests verify the contract; the implementation is whatever makes the tests pass.
+
+This is deliberate. A testing agent who reads the implementation first writes tests that match the implementation. Those tests are decorative — they pass against any code that happens to be shaped the same way, rather than encoding the spec's invariants. A testing agent who reads only the spec writes tests that can FAIL when the implementation diverges from the spec — which is what testing is for.
+
+## When you MAY read implementation
+
+- To get the exact symbol name to import (e.g. `from src.data_fetcher import fetch_series`). Read only the `__init__.py` or the top of the module to get exports.
+- To confirm a type signature your test must match. Read the function signature, not its body.
+- The spec explicitly says "the implementation in `src/X` is canonical; tests must verify against it". Rare.
+
+If you find yourself reading an implementation body to figure out "how should I structure this test?", stop. Re-read the spec section that governs this test case. The spec should be enough; if it isn't, the spec is underspecified — report that.
+
+## Inputs the caller will provide
+
+- The GitHub issue number (`#N`) your branch corresponds to.
+- The spec file(s) under `specs/` that govern the tests you're writing.
+- For each spec, which "Test cases" subsections you should implement (usually: all of them).
+- The branch name. You are already on it.
+- The testing-and-CI spec (`specs/testing_and_ci.md`) is always in scope — your tests MUST conform to its marker conventions (`unit` / `integration` / `spec`), conftest helpers, and pyproject configuration.
+
+## Contract
+
+1. **Read the specs first, in full.** Then write tests. Write each test from the spec, run it once, and report the outcome — don't edit tests incrementally against passing/failing signals.
+2. **Mark every test.** Every test carries at least one marker: `@pytest.mark.unit`, `@pytest.mark.integration`, or `@pytest.mark.spec`. Tests that verify a "Test cases" entry in a `specs/*.md` file MUST be marked `@pytest.mark.spec` with a docstring referencing the spec section and the specific case. Example:
+
+   ```python
+   @pytest.mark.unit
+   @pytest.mark.spec
+   def test_walk_forward_never_reads_future_rows():
+       """specs/backtester.md §'Walk-forward constraint' test case 2:
+       the backtester at date T must not access any row with index > T."""
+   ```
+
+3. **Test what the spec specifies, and only that.** If you think a test is valuable and it's not in a spec, stop and report — the coordinator decides whether to update the spec or defer. Adding invariants the spec doesn't state is out of scope.
+4. **When a spec test case is infeasible as written, report the ambiguity.** Infeasible means: ambiguous, impossible to encode with available tooling, or requires state the framework can't provide. The correct output is a one-line report to the coordinator, not a modified spec, not a modified implementation, not a weaker test that passes.
+5. **Write from the spec alone — do not read the implementation to fill gaps.** If a test requires an invariant the spec doesn't pin, stop and report "spec §X doesn't pin <behaviour>; parser/fetcher/classifier expects <format>; which is canonical?" and let the coordinator resolve it. The counterintuitive trap: reading the implementation to "figure out what the spec means" collapses the maker-checker boundary — your tests become decorative because they're shaped to the code they're supposedly verifying. Green tests produced this way are worse than failing tests: they make bugs invisible. (See worked example below.)
+6. **Cite spec text, never spec inference.** When a test docstring or your final report cites a spec invariant, the cited text MUST appear in the spec as written (or be an exact quote of a spec clause). If you find yourself writing "the spec implies X" or "canonical per §Y" where §Y doesn't say that, that's the signal to stop and report — you're about to invent a spec clause.
+7. **Change fixtures only with explicit spec authority.** Modifying shared fixtures, golden files, or seeded test data is permitted only when the change brings the data into compliance with a specific, quoted spec invariant. "The implementation expects this format" is NOT spec authority. If a fixture contradicts the implementation and neither the spec nor the fixture's own docstring pins the expected shape, stop and report the discrepancy — the coordinator decides whether the fixture, the implementation, or the spec needs to change.
+8. **Done = tests written from the spec, run, and all ambiguities surfaced as first-class report items.** Green tests alone are not done. Clean tests with an explicit ambiguity list IS done, even if that list is long. This is the rule most worth holding onto because it runs against the instinct to hand back a clean green result: the ambiguity report is part of the deliverable, not an embarrassment.
+9. **Respect the effort budget.** If you exceed 2× without a clearly complete suite, stop and report.
+10. **Run the tests before committing.**
+
+    ```bash
+    pytest -m "not integration"
+    ```
+
+    Must pass. If a test you wrote per spec FAILS against the current implementation, that is exactly the signal your role exists to produce — the implementation has a bug relative to the spec. Do NOT modify the test to make it pass. Stop and report: "test X (per spec Y §Z) fails against the current implementation — message: `<failure message>`". The coordinator redirects to the coding agent to fix the implementation; you re-run the tests.
+
+11. **Every commit has the trailer.**
+    ```
+    Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+    ```
+12. **Do NOT push the branch or open a PR.** The coordinator handles that after all tests pass.
+13. **Do NOT update `src/`, `scripts/`, `configs/`, `specs/`, `CLAUDE.md`, or `.claude/`.** You only touch `tests/` and (if necessary) `pyproject.toml` to wire up pytest configuration per `specs/testing_and_ci.md`.
+
+## Worked example: the "post_date" episode (sibling project, 2026-04)
+
+This is what rule 5 looks like in the wild. A testing agent in sibling project `opc-ev-reporting` (MR !12, captured in issue #16) was writing tests for a KFS parser. The existing fixture had `post_date` values in `YYYY-MM-DD`; the coding agent's `parse_post_date` used `%m/%d/%y`. Reading the parser implementation for "context," the testing agent:
+
+1. Cited an invariant in a test docstring — "spec says canonical KFS format is MM/DD/YY" — that did not appear in the spec. The spec pinned no date format.
+2. Edited the fixture from `YYYY-MM-DD` to `MM/DD/YY` to match the parser's behavior.
+3. Reported the resulting passing tests as success.
+
+Ground truth: real KFS exports use `YYYY-MM-DD` natively. The parser's `%m/%d/%y` was a coding-agent bug. The testing agent's "fixture correction" aligned both halves of the test loop to the wrong format, making the bug invisible. `/review-pr` nearly missed it.
+
+The correct response would have been one line: "fixture is `YYYY-MM-DD`, parser expects `MM/DD/YY`, spec pins neither — which is canonical?" One sentence of ambiguity report would have caught the bug. Instead, decorative-but-green tests almost shipped a broken parser.
+
+The lesson: **your signal value comes from your blindness to the implementation.** When in doubt, report and ask rather than read and infer.
+
+## Final message to the coordinator
+
+Your final message MUST include:
+
+1. Counts: tests per module, broken down by marker (`unit` / `integration` / `spec`).
+2. The full output of `pytest -m "not integration"` (pass/fail/skip).
+3. The output of `pytest -m spec` so coordinator can see which spec-anchored tests are discoverable.
+4. The commit SHA(s) you produced.
+5. **Any test in a spec's "Test cases" section you could NOT implement, and why.** Explicitly. Missing cases without explanation is a contract violation.
+6. **Any test you wrote that failed against the current implementation**, with the failure message and the spec case it encodes. This is the signal that the coding agent has a bug. Name them clearly.
+
+Keep it short. The coordinator reads the diff; your message indexes it.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,19 +103,20 @@ you're about to stabilize, write the spec BEFORE the refactor.
   and add a test. The spec grows from real failures, not hypothetical ones.
 - **Every PR touching a specced component** should reference the relevant spec and
   note whether the spec was updated as part of the change.
-- **At delegation time:** before spawning a coding agent, the coordinator MUST
-  state the branch prefix in the delegation prompt and the rationale. If the
-  prefix is `stable/`, the spec MUST exist before the implementation delegation
-  (not written concurrently). The coordinator's first commit on a `stable/`
-  branch MUST be the spec; implementation delegations follow. This is enforced
-  by the file-type rule in the Workflow section — tests, `src/` code, or
-  `configs/` changes in a delegation prompt mean `stable/` and spec-first, no
-  exceptions. For `stable/` delegations, the coordinator MUST also cite the
-  upstream `explore/` branch or research artifact that informed the spec, or
-  explicitly acknowledge "no upstream exploration; risk of spec drift during
-  implementation is accepted" (see Workflow section's "Typical phased flow").
-- **Coding-agent commit attribution:** coding agents MUST include a
-  `Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>`
+- **At delegation time:** before spawning a coding agent or testing agent,
+  the coordinator MUST state the branch prefix in the delegation prompt and
+  the rationale. If the prefix is `stable/`, the spec MUST exist before the
+  implementation delegation (not written concurrently). The coordinator's
+  first commit on a `stable/` branch MUST be the spec; implementation
+  delegations follow. This is enforced by the file-type rule in the Workflow
+  section — tests, `src/` code, or `configs/` changes in a delegation prompt
+  mean `stable/` and spec-first, no exceptions. For `stable/` delegations,
+  the coordinator MUST also cite the upstream `explore/` branch or research
+  artifact that informed the spec, or explicitly acknowledge "no upstream
+  exploration; risk of spec drift during implementation is accepted" (see
+  Workflow section's "Typical phased flow").
+- **Agent commit attribution:** coding agents and testing agents MUST include a
+  `Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>`
   (or equivalent current-model) trailer on every commit they produce. The
   coordinator MUST state this requirement in every delegation prompt. Rationale:
   the maker-checker model's provenance boundary (coordinator-authored specs,
@@ -322,12 +323,12 @@ Worktree-based isolation may be revisited in a future Claude Code version
 where the wrinkles (settings inheritance, env-var propagation, hook semantics)
 are smoother.
 
-**Background by default:** Coding agents should run with `run_in_background: true`
-when the task is well-specified. The spec is the contract — if the spec is complete,
-the agent doesn't need to interrupt the user for clarification. The coordinator can
-continue other work and is notified when the agent completes. If the agent gets
-stuck, a review agent catches issues after completion; we don't lose time to
-mid-task interruptions.
+**Background by default:** Coding agents and testing agents should run with
+`run_in_background: true` when the task is well-specified. The spec is the
+contract — if the spec is complete, the agent doesn't need to interrupt the
+user for clarification. The coordinator can continue other work and is
+notified when the agent completes. If the agent gets stuck, `review-pr`
+catches issues after completion; we don't lose time to mid-task interruptions.
 
 Exceptions (run foreground): when the spec is still being negotiated, when the
 task is a tight feedback loop, or when the coordinator needs the result immediately

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -204,6 +204,7 @@ The "about to be depended on by other components" criterion in the spec lifecycl
 
 - **Any PR that creates or modifies files in `src/`, `tests/`, or `configs/` is stabilizing by default**, regardless of how exploratory the research intent feels. Such PRs MUST use `stable/` and the spec MUST be written first.
 - `explore/` MUST be used only when the work is purely in `notebooks/`, `docs/research/`, or `data/`.
+- **`fix/` exception for behavior-preserving fixes.** A `fix/` PR that touches `src/`, `tests/`, or `configs/` MAY skip the spec-first discipline when the fix is strictly behavior-preserving against an invariant the spec already pins (e.g., correcting a silently-wrong calculation that a spec clause specifies). If the bug reveals a *missing* invariant, the fix is no longer purely behavior-preserving — update the spec as part of the PR, which means spec-first applies. In doubt, treat it as `stable/`.
 - If a single stream of work needs both — a research notebook AND a new data-fetcher module — it MUST be split into two PRs: one `explore/` for the analytical output, one `stable/` for the infrastructure. Different branches, different review standards.
 - Mixed-scope in one PR is permitted only with explicit justification in the PR body and coordinator sign-off. The default is split.
 
@@ -242,13 +243,26 @@ branches must reference the spec they conform to.
 ### Maker-checker model
 
 The main Claude instance is a **coordinator**, not a coder. All code is written by
-subagents and reviewed before merging.
+subagents and reviewed before merging. Four roles:
 
 | Role | Who | Responsibility |
 |---|---|---|
-| **Coordinator** | Main instance | Spec management, task delegation, merge decisions. Does not write code. |
-| **Coding agent** | Subagent | Implements on a branch per the spec. Commits to the branch. |
-| **Review agent** | Subagent | Reviews implementation against the spec. Flags deviations, missing tests, edge cases. |
+| **Coordinator** | Main instance | Spec authorship, task delegation, merge decisions. Does not write code. |
+| **Coding agent** | Subagent (`subagent_type: coding-agent`) | Implements `src/`, `scripts/`, or `configs/` code against the spec. Commits to the branch. |
+| **Testing agent** | Subagent (`subagent_type: testing-agent`) | Writes `tests/` against the spec, **blind to the implementation**. Separate spawn from the coding agent. If tests fail, that's a coding-agent bug to fix — not a spec to loosen, not a test to weaken. |
+| **Review agent** | Subagent (e.g. `subagent_type: review-pr`) | Scope, code quality, governance-gate checks, docs alignment. Trusts that the testing agent already verified spec conformance via passing tests. |
+
+#### Why the testing agent is separate from the coding agent
+
+A single agent who writes both the implementation AND the tests writes **decorative tests** — tests that happen to pass against the code they just wrote but don't actually encode the spec's invariants. The same intuitions that shape the code shape the tests; blind spots propagate to both sides of the loop. A testing agent spawned separately, reading only the spec, writes tests that FAIL when the implementation diverges from the spec — which is what testing is for. Failing tests then become the definitive signal of an implementation-vs-spec mismatch, not a nuisance to silence.
+
+This separation is load-bearing enough to have its own failure mode documented: see the "post_date episode" worked example in `.claude/agents/testing-agent.md` (rule 5). A testing agent that reads implementation to fill spec gaps will align fixtures to the code's shape, produce green tests, and make bugs invisible. That risk is why the testing-agent charter treats implementation-reading as a last resort and fixture-realignment as requiring explicit spec authority.
+
+Spawn pattern by task type:
+
+- **Code + tests task (most common for `stable/`):** two sequential delegations. Coding agent first → testing agent spawned fresh (no conversational context from the coding-agent delegation) → if tests fail, redirect to coding agent to fix implementation, then testing agent re-runs. Iterate until green.
+- **Tests-only task** (filling in a test suite for already-reviewed existing code): testing agent is the only implementer. The decorative-tests risk doesn't apply — the agent didn't author the code being tested.
+- **Code-only task** (fix that changes internal behavior without expanding the spec's test cases): coding agent is the only implementer; `review-pr` is the verification. Should be rare — most code changes benefit from a corresponding testing-agent pass.
 
 #### Coordinator deny list
 
@@ -272,15 +286,17 @@ The coordinator's editable surface is everything else: `CLAUDE.md`, `.claude/` (
 
 If you (the coordinator) catch yourself reaching for `Edit` or `Write` on a deny-listed path, stop and delegate. Even one-line fixes go through an agent — the boundary is what makes the maker-checker model work, and the boundary erodes one "just this once" at a time.
 
-**The flow:**
-1. Coordinator reads the spec (or writes/updates it if needed)
-2. Coordinator creates the branch and delegates to a coding agent with the spec and context
-3. Coding agent implements and commits on the current branch
-4. Coordinator delegates to a review agent to check implementation against spec
-5. Coordinator reviews findings, approves or sends back
-6. Coordinator pushes the branch and opens a pull request (never merges locally to main)
-7. Before merging, coordinator runs a **pre-merge review** of the PR — either via `/review-pr <number>` (which delegates to the `review-pr` subagent defined at `.claude/agents/review-pr.md`) or by spawning the agent directly with `Agent(subagent_type="review-pr", ...)`. The agent's report ends with an embedded `## Pre-merge review` block; the coordinator (or `/review-pr`) posts that block verbatim as a PR comment immediately, and on merge approval includes the same block in the merge commit body via `gh pr merge --body`. Same review lands in two durable places: the PR thread on GitHub (visible to author and future readers) and the merge commit (permanent, surfaces in `git log`). Merge only on PASS or PASS-WITH-NITS (see #15 for the Level 1/2/3 escalation path toward CI enforcement)
-8. Work is landed by merging the PR — this preserves a reviewable artifact, keeps a searchable history, and gives CI and the review agent a surface to hook into
+**The flow (for any PR whose diff crosses the coordinator deny list):**
+1. Coordinator reads the spec (or writes/updates it if needed — `specs/` is coordinator territory)
+2. Coordinator creates the branch and delegates implementation. The pattern depends on the task:
+   - **Code + tests task (most common for `stable/`):** two sequential delegations.
+     - **2a.** Coding agent: implements `src/` / `scripts/` / `configs/` per the spec. Reports back with diff and commit SHA.
+     - **2b.** Testing agent: spawned fresh (do not continue the coding-agent conversation). Given only the spec and branch, writes `tests/` blind to the implementation and runs them. If tests fail, that is the signal that the coding agent has a bug — redirect to coding agent to fix the implementation, then testing agent re-runs. Iterate until green. Do NOT loosen tests or weaken the spec to accommodate failures.
+   - **Tests-only task:** single testing-agent delegation.
+   - **Code-only task** (rare — behavior-preserving fix whose spec's test cases are already covered): single coding-agent delegation.
+3. Coordinator pushes the branch and opens a pull request (never merges locally to main)
+4. Coordinator runs a **pre-merge review** of the PR — either via `/review-pr <number>` (which delegates to the `review-pr` subagent defined at `.claude/agents/review-pr.md`) or by spawning the agent directly with `Agent(subagent_type="review-pr", ...)`. The agent checks scope, code quality, governance gates, and docs alignment; spec conformance is already verified by the passing tests from step 2b. The agent's report ends with an embedded `## Pre-merge review` block; the coordinator (or `/review-pr`) posts that block verbatim as a PR comment immediately (regardless of verdict), and on merge approval includes the same block in the merge commit body via `gh pr merge --body`. Same review lands in two durable places: the PR thread (visible to author and future readers) and the merge commit (permanent, surfaces in `git log`). Merge only on PASS or PASS-WITH-NITS (see #15 for the Level 1/2/3 escalation path toward CI enforcement).
+5. Work is landed by merging the PR — this preserves a reviewable artifact, keeps a searchable history, and gives CI and the review agent a surface to hook into.
 
 **Coding agents work in the main checkout, not worktrees.** Earlier versions of
 this workflow used `isolation: "worktree"` for filesystem isolation, but for a
@@ -340,11 +356,14 @@ exact command and error" has succeeded. An agent that creates a wrapper script
 to launder the same command past the allowlist has failed the contract even
 if the code technically works.
 
-Every coding agent delegation prompt must explicitly state:
+Every coding-agent or testing-agent delegation prompt must explicitly state:
 - **Scope boundaries** — list what is out of scope (config files, unrelated
   modules, other components' specs)
 - **Report-don't-patch** — if a tool or script can't run, report it back
   rather than inventing workarounds
+- **Commit trailer** — `Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>`
+- **Effort budget and early-exit conditions**
+- For `stable/` delegations, the upstream `explore/` branch or research artifact that informed the spec (or explicit acknowledgment that none exists — see "Typical phased flow" above)
 
 **Why:** Separating writing from reviewing catches errors that flow-state coding misses.
 The coordinator stays at the spec level and never gets pulled into implementation details.


### PR DESCRIPTION
Closes #114.

## Summary

Adopts the coding-agent / testing-agent role separation from sibling project `opc-ev-reporting`. The core insight: a single agent writing both implementation and tests writes **decorative tests** — tests shaped to the code rather than shaped to the spec. Separating the roles, with the testing agent blind to the implementation, makes failing tests a definitive signal of an implementation-vs-spec mismatch.

Also incorporates a second lesson from sibling issue [#16](https://gitlab01.classe.cornell.edu/dd55/opc-ev-reporting/-/work_items/16): for testing agents, **improvising to green is failure, not success**. A testing agent that reads implementation to fill spec gaps aligns fixtures to buggy code, produces green tests, and makes bugs invisible. The testing-agent charter explicitly treats this as a contract violation, with a worked "post_date" example.

## Changes

**New files:**
- `.claude/agents/coding-agent.md` — charter for the coding-agent role.
- `.claude/agents/testing-agent.md` — charter for the testing-agent role, with rules 5–8 encoding the issue-#16 tightening.

**CLAUDE.md updates (maker-checker section):**
- Role table expanded from three to four rows.
- New *Why the testing agent is separate from the coding agent* subsection.
- Flow rewritten as two-phase delegation (coding-agent → testing-agent → review-pr), with explicit patterns for code-only and tests-only tasks.
- `fix/` exception added to the file-type heuristic: behavior-preserving fixes against already-specced invariants may skip spec-first discipline.
- Delegation-prompt checklist expanded to cover both agent types and include the commit-trailer requirement inline.

## Spec alignment

This PR is coordinator-authored prose only — CLAUDE.md and `.claude/agents/*`. No `src/`, `tests/`, `configs/`, or `scripts/` are touched, so the file-type heuristic does not require a stabilizing spec. The change IS itself a harness-spec change (CLAUDE.md is the governance spec).

## Context

This PR is the first of five harness-related items identified in session on 2026-04-19:

- **This PR** — testing-agent separation (retrospective issue #114).
- [#112](https://github.com/dsdale24/big-cycle-investing/issues/112) — adopt `harness/` branch prefix.
- [#110](https://github.com/dsdale24/big-cycle-investing/issues/110) — squash-merge default for deny-list PRs.
- [#111](https://github.com/dsdale24/big-cycle-investing/issues/111) — branch protection on main.
- [#113](https://github.com/dsdale24/big-cycle-investing/issues/113) — collapse `explore/`/`stable/` into `feat/`.

## Test plan

- [ ] Read CLAUDE.md §Maker-checker model end-to-end — role table, why-separate subsection, and flow should read as a coherent story.
- [ ] Read `.claude/agents/coding-agent.md` and `.claude/agents/testing-agent.md` for internal consistency.
- [ ] Verify testing-agent.md §Worked example reads as instruction (what to do differently), not just war story.
- [ ] Verify the `fix/` exception in the file-type heuristic is narrow enough that it doesn't re-open the governance hole it closed (behavior-preserving only; missing invariants → spec update required).
- [ ] Spot-check that no deny-list paths were touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)