### PR TITLE
Document branch protection on main (closes #111)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -190,6 +190,15 @@ See `reviews/README.md` for the full documentation.
 **All work happens on branches. Never commit directly to main, and never merge
 branches locally to main — always land changes via a pull request.**
 
+**Branch protection on `main` is enforced at the GitHub level** (configured 2026-04-19, per #111). The rule is mechanical, not discipline-only:
+
+- Every change to `main` requires a pull request (`required_pull_request_reviews.required_approving_review_count: 0` — PR required, approval not required since this is a solo project).
+- Linear history required (`required_linear_history: true`) — blocks merge commits, forces squash-merge or rebase. Aligns with #110's squash-merge default.
+- `enforce_admins: true` — the rule applies to the repo owner too. No admin bypass for "just this once" pushes. If a genuine emergency bypass is needed, toggle `enforce_admins: false` explicitly, push, toggle back — the toggle is itself an auditable action.
+- Force-pushes blocked; deletions blocked.
+
+The protection can be inspected with `gh api repos/dsdale24/big-cycle-investing/branches/main/protection`. To reproduce if ever revoked, the exact API call is in the PR body for #111. Status checks are deferred until CI exists (see #15).
+
 | Branch prefix | Purpose | Spec required? |
 |---------------|---------|----------------|
 | `explore/{phase}/{feature}` | Exploratory work — notebooks, research notes, prototypes | No |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -197,7 +197,7 @@ branches locally to main — always land changes via a pull request.**
 - `enforce_admins: true` — the rule applies to the repo owner too. No admin bypass for "just this once" pushes. If a genuine emergency bypass is needed, toggle `enforce_admins: false` explicitly, push, toggle back — the toggle is itself an auditable action.
 - Force-pushes blocked; deletions blocked.
 
-The protection can be inspected with `gh api repos/dsdale24/big-cycle-investing/branches/main/protection`. To reproduce if ever revoked, the exact API call is in the PR body for #111. Status checks are deferred until CI exists (see #15).
+The protection can be inspected with `gh api repos/dsdale24/big-cycle-investing/branches/main/protection`. To reproduce if ever revoked, the exact `PUT` payload is preserved in the landing commit for #111 (run `git log --grep='#111' --all` to find it). Status checks are deferred until CI exists (see #15).
 
 | Branch prefix | Purpose | Spec required? |
 |---------------|---------|----------------|


### PR DESCRIPTION
Closes #111.

## Summary

Branch protection was applied to \`main\` on 2026-04-19 via \`gh api\` after the repo was made public (required for free-tier branch protection). This PR adds a one-paragraph note to CLAUDE.md's Workflow section documenting the settings and how to reproduce them.

## Settings applied

| Field | Value | Purpose |
|---|---|---|
| \`required_pull_request_reviews\` | \`{required_approving_review_count: 0}\` | PR required; approval not required (solo project) |
| \`required_linear_history\` | \`true\` | Blocks merge commits → forces squash (aligns with #110) |
| \`enforce_admins\` | \`true\` | Rule applies to repo owner; no admin bypass |
| \`allow_force_pushes\` | \`false\` | No history rewrites on \`main\` |
| \`allow_deletions\` | \`false\` | \`main\` can't be deleted |
| \`required_status_checks\` | \`null\` | Deferred until CI exists (see #15) |

## Reproduce if revoked

\`\`\`bash
cat <<'JSON' | gh api --method PUT repos/dsdale24/big-cycle-investing/branches/main/protection --input -
{
  "required_status_checks": null,
  "enforce_admins": true,
  "required_pull_request_reviews": {
    "required_approving_review_count": 0,
    "dismiss_stale_reviews": false,
    "require_code_owner_reviews": false
  },
  "restrictions": null,
  "required_linear_history": true,
  "allow_force_pushes": false,
  "allow_deletions": false
}
JSON
\`\`\`

## Why \`enforce_admins: true\` is load-bearing

Without it, the rule becomes optional for the repo owner (i.e., every push I make). That's the exact state #111 was filed to replace. With it, even I can't push directly to \`main\` — which is what "mechanical enforcement instead of discipline" means. If a genuine emergency bypass is ever needed, toggle \`enforce_admins: false\`, push, toggle back — the toggle itself is auditable.

## Test plan

- [x] Branch protection API call succeeded and returns expected state
- [x] This PR itself exercises the rule — it can only be merged through the PR flow now
- [ ] Confirm the new CLAUDE.md paragraph reads as a clear decision record (no ambiguity about \`enforce_admins\`)
- [ ] The reproduce-command block is copy-pasteable

## Verification

Branch protection state can be inspected anytime with:

\`\`\`bash
gh api repos/dsdale24/big-cycle-investing/branches/main/protection
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)