### PR TITLE
Record changelog checks through v2.1.119 (2026-04-24)

### DIFF
--- a/.claude/skills/changelog-check/state.json
+++ b/.claude/skills/changelog-check/state.json
@@ -1,5 +1,5 @@
 {
-  "last_version": "2.1.108",
-  "last_checked": "2026-04-14",
-  "notes": "2.1.107/108: 0 #33 ticks; relevant: ENABLE_PROMPT_CACHING_1H, Skill-tool discovers built-in slash commands, /recap feature."
+  "last_version": "2.1.119",
+  "last_checked": "2026-04-24",
+  "notes": "2.1.113-119: no action items. Worktree fixes landed (stale-worktree cleanup, PR linking) but load-bearing wrinkles (env-var/settings inheritance, permission slicing, data-cache, hook semantics) unchanged — no revisit of isolation model. Notable: native macOS/Linux binary (2.1.113), /ultrareview UI improvements (touches #108), MCP parallel reconnect (2.1.119)."
 }


### PR DESCRIPTION
State bump only: `.claude/skills/changelog-check/state.json` updated from \`2.1.108 @ 2026-04-14\` to \`2.1.119 @ 2026-04-24\`. Captures two checks:

- **2026-04-18** at v2.1.112 (was sitting uncommitted in the working tree since prior session).
- **2026-04-24** at v2.1.119 (today's user-requested worktree-fix lookup).

**Today's check findings (short):** no action items.

Two worktree-adjacent fixes landed in 2.1.119 — stale-worktree cleanup, PR/worktree linking — but the **load-bearing wrinkles** CLAUDE.md cites for why this project abandoned \`isolation: "worktree"\` (env-var / settings inheritance, subagent permission slicing, data-cache absence, hook semantics) remain unaddressed. No revisit of the isolation model warranted.

Other notable items (not action-requiring): native macOS/Linux binary with embedded bfs/ugrep (2.1.113), /ultrareview UI improvements touching #108, MCP server parallel reconnect (2.1.119).

## Scope

- One file touched: \`.claude/skills/changelog-check/state.json\`
- No deny-list paths; no code, tests, or configs
- Harness PR per PR #116's branch-prefix convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)